### PR TITLE
chore(monitoring): promote from incubator to prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ jobs:
           statuspage_name: Helix Content Proxy
           statuspage_group: Delivery
           newrelic_group_policy: Delivery Repeated Failure
-          incubator: true # remove only when promoting service to production
 
   branch-deploy:
     executor: node10


### PR DESCRIPTION
`helix-content-proxy` has been running in production for a while now.