### PR TITLE
fix(json): request fresh data from helix-data-embed

### DIFF
--- a/src/excel-json.js
+++ b/src/excel-json.js
@@ -49,7 +49,11 @@ async function handleJSON(opts, params) {
 
     try {
       log.debug(`fetching data from ${url}`);
-      const response = await fetch(url, getFetchOptions(options));
+
+      const fopts = getFetchOptions(options);
+      fopts.headers['cache-control'] = 'no-cache'; // respected by runtime
+
+      const response = await fetch(url, fopts);
       const sourceLocation = response.headers.get('x-source-location') || itemUri.pathname;
       if (response.ok) {
         return {

--- a/src/google-json.js
+++ b/src/google-json.js
@@ -39,7 +39,10 @@ async function handleJSON(opts, params) {
       src: sheetURL,
     });
 
-    const response = await fetch(url, getFetchOptions(options));
+    const fopts = getFetchOptions(options);
+    fopts.headers['cache-control'] = 'no-cache'; // respected by runtime
+
+    const response = await fetch(url, fopts);
     const body = await response.json();
     if (response.ok) {
       // if the backend does not provide a source location, use the sheetId

--- a/test/excel-json.test.js
+++ b/test/excel-json.test.js
@@ -167,24 +167,24 @@ describe('Excel JSON Integration tests', () => {
     });
     assert.deepEqual(res.body, [
       {
-        'import date': '2020-06-24T07:45:30.983Z',
-        url: 'https://theblog.adobe.com/how-retailers-can-build-relationships-with-customers-from-a-distance/',
-        year: 44005,
+        'import date': '2020-07-22T13:35:27.404Z',
+        url: 'https://theblog.adobe.com/adobe-ibm-and-red-hat-partner-to-advance-customer-experience-transformation/',
+        year: 44033,
       },
       {
-        'import date': '2020-06-24T07:45:30.986Z',
-        url: 'https://theblog.adobe.com/u-s-executive-order-on-immigration-2020/',
-        year: 44005,
+        'import date': '2020-07-22T13:35:27.408Z',
+        url: 'https://theblog.adobe.com/wipro-accelerates-the-paperless-enterprise-with-adobe-sign/',
+        year: 44033,
       },
       {
-        'import date': '2020-06-24T07:45:30.988Z',
-        url: 'https://theblog.adobe.com/build-for-good-adobe-document-cloud-and-topcoder-host-developer-challenge-powered-by-adobe-pdf-sdks/',
-        year: 44005,
+        'import date': '2020-07-22T13:35:27.474Z',
+        url: 'https://theblog.adobe.com/getting-more-from-your-crm-data/',
+        year: 44032,
       },
       {
-        'import date': '2020-06-24T07:45:31.715Z',
-        url: 'https://theblog.adobe.com/reimagining-customer-loyalty-through-value-driven-strategies/',
-        year: 44005,
+        'import date': '2020-07-22T13:35:28.111Z',
+        url: 'https://theblog.adobe.com/the-emoji-year-in-review/',
+        year: 44029,
       },
     ]);
   }).timeout(50000);

--- a/test/fixtures/Excel-JSON-Integration-tests_3656940029/Get-JSON_3236052051/recording.har
+++ b/test/fixtures/Excel-JSON-Integration-tests_3656940029/Get-JSON_3236052051/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "d7e37c9f9204d48bbaa222dd2f07ceca",
+        "_id": "1f11bf17ed8f8d8fac1c5cf363347a4c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -32,11 +32,15 @@
               "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
             },
             {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
               "name": "host",
               "value": "adobeioruntime.net"
             }
           ],
-          "headersSize": 420,
+          "headersSize": 445,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -52,11 +56,11 @@
           "url": "https://adobeioruntime.net/api/v1/web/helix/helix-services/data-embed@v1?hlx_p.limit=4&src=onedrive%3A%2Fdrives%2Fb%21PpnkewKFAEaDTS6slvlVjh_3ih9lhEZMgYWwps6bPIWZMmLU5xGqS4uES8kIQZbH%2Fitems%2F01DJQLOW65RTXCQHBBGZFZ6IHSOUITJM2C"
         },
         "response": {
-          "bodySize": 690,
+          "bodySize": 612,
           "content": {
             "mimeType": "application/json",
-            "size": 690,
-            "text": "[{\n  \"import date\": \"2020-06-24T07:45:30.983Z\",\n  \"url\": \"https://theblog.adobe.com/how-retailers-can-build-relationships-with-customers-from-a-distance/\",\n  \"year\": 44005\n}, {\n  \"import date\": \"2020-06-24T07:45:30.986Z\",\n  \"url\": \"https://theblog.adobe.com/u-s-executive-order-on-immigration-2020/\",\n  \"year\": 44005\n}, {\n  \"import date\": \"2020-06-24T07:45:30.988Z\",\n  \"url\": \"https://theblog.adobe.com/build-for-good-adobe-document-cloud-and-topcoder-host-developer-challenge-powered-by-adobe-pdf-sdks/\",\n  \"year\": 44005\n}, {\n  \"import date\": \"2020-06-24T07:45:31.715Z\",\n  \"url\": \"https://theblog.adobe.com/reimagining-customer-loyalty-through-value-driven-strategies/\",\n  \"year\": 44005\n}]"
+            "size": 612,
+            "text": "[{\n  \"import date\": \"2020-07-22T13:35:27.404Z\",\n  \"url\": \"https://theblog.adobe.com/adobe-ibm-and-red-hat-partner-to-advance-customer-experience-transformation/\",\n  \"year\": 44033\n}, {\n  \"import date\": \"2020-07-22T13:35:27.408Z\",\n  \"url\": \"https://theblog.adobe.com/wipro-accelerates-the-paperless-enterprise-with-adobe-sign/\",\n  \"year\": 44033\n}, {\n  \"import date\": \"2020-07-22T13:35:27.474Z\",\n  \"url\": \"https://theblog.adobe.com/getting-more-from-your-crm-data/\",\n  \"year\": 44032\n}, {\n  \"import date\": \"2020-07-22T13:35:28.111Z\",\n  \"url\": \"https://theblog.adobe.com/the-emoji-year-in-review/\",\n  \"year\": 44029\n}]"
           },
           "cookies": [],
           "headers": [
@@ -82,11 +86,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 20 Jul 2020 02:12:35 GMT"
+              "value": "Thu, 20 Aug 2020 10:02:29 GMT"
             },
             {
               "name": "perf-br-resp-out",
-              "value": "1595211155.828"
+              "value": "1597917749.584"
             },
             {
               "name": "strict-transport-security",
@@ -102,19 +106,19 @@
             },
             {
               "name": "x-gw-cache",
-              "value": "MISS"
+              "value": "BYPASS"
             },
             {
               "name": "x-last-activation-id",
-              "value": "9327144ae7ff408ba7144ae7ff108be1"
+              "value": "9f94e7fb1c834c2094e7fb1c83fc2007"
             },
             {
               "name": "x-openwhisk-activation-id",
-              "value": "83d7e5f076c5449297e5f076c53492cd"
+              "value": "5aa6fa1f98c8486ba6fa1f98c8e86b64"
             },
             {
               "name": "x-request-id",
-              "value": "YkNIxf4pTJWansfgxJ6PX6mUntzaPlMx"
+              "value": "LC7BMg7lttyX7wrx7vyYYqmR4SQeGpgp"
             },
             {
               "name": "x-xss-protection",
@@ -122,21 +126,21 @@
             },
             {
               "name": "content-length",
-              "value": "690"
+              "value": "612"
             },
             {
               "name": "connection",
               "value": "keep-alive"
             }
           ],
-          "headersSize": 749,
+          "headersSize": 751,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-07-20T02:12:28.609Z",
-        "time": 7279,
+        "startedDateTime": "2020-08-20T10:02:20.992Z",
+        "time": 8648,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -144,7 +148,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 7279
+          "wait": 8648
         }
       }
     ],


### PR DESCRIPTION
Adobe I/O Runtime respects the `no-cache` directive in the `Cache-Control` *request* header, which will allow us to do a partial revert of https://github.com/adobe/helix-data-embed/pull/131 and keep some caching as the default

see https://github.com/adobe/helix-data-embed/issues/153

