### PR TITLE
fix(request): return 404 for paths with double slashes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ async function main(mainopts) {
   // validate path parameter
   if (path.indexOf('//') > -1) {
     return {
-      statusCode: 400,
+      statusCode: 404,
       body: `invalid path: ${path}`,
     };
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -54,7 +54,7 @@ mountpoints:
     assert.equal(result.statusCode, 501);
   });
 
-  it('index returns 400 on invalid path', async function invalidPath() {
+  it('index returns 404 on invalid path', async function invalidPath() {
     const { server } = this.polly;
 
     server
@@ -70,7 +70,7 @@ mountpoints:
       path: '//foo/index.md',
     });
 
-    assert.equal(result.statusCode, 400);
+    assert.equal(result.statusCode, 404);
   });
 
   it('index returns 404 if no reverse handler can process the lookup', async function noReverse() {


### PR DESCRIPTION
fixes #152

