### PR TITLE
feat(lookup): add lookup report feature

### DIFF
--- a/src/google-reverse.js
+++ b/src/google-reverse.js
@@ -56,8 +56,7 @@ async function reverseLookup(opts) {
   }
   const ext = type === 'spreadsheets' ? '.json' : '.html';
 
-  // make author un-friendly
-  return encodeURI(filename2url(decodeURI(`${path}${ext}`)));
+  return `${path}${ext}`;
 }
 
 module.exports = {

--- a/src/google-reverse.js
+++ b/src/google-reverse.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 const { getPathFromId } = require('./google-helpers.js');
-const { filename2url } = require('./filename-to-url.js');
 
 function test(uri) {
   return uri.hostname === 'drive.google.com'

--- a/src/index.js
+++ b/src/index.js
@@ -147,6 +147,7 @@ async function main(mainopts) {
           ref,
           options: externalOptions,
           log,
+          report: !!mainopts.report,
         });
       }
       if (mainopts.edit) {

--- a/src/onedrive-reverse.js
+++ b/src/onedrive-reverse.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 const { OneDrive } = require('@adobe/helix-onedrive-support');
-const { filename2url } = require('./filename-to-url.js');
 
 function test(uri) {
   return /^.+\.sharepoint.com$/.test(uri.hostname);
@@ -94,8 +93,6 @@ async function reverseLookup(opts) {
     }
     log.info('path/host from id:', docPath, docHost);
   }
-  // make author un-friendly
-  docPath = encodeURI(filename2url(decodeURI(docPath)));
 
   // find mountpoint that matches the document path and root
   return mount.mountpoints.reduce((path, mp) => {

--- a/src/reverse.js
+++ b/src/reverse.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
+const { filename2url } = require('./filename-to-url.js');
 const google = require('./google-reverse.js');
 const onedrive = require('./onedrive-reverse.js');
 // const github = require('./github-reverse.js');
@@ -27,6 +27,7 @@ async function reverseLookup(opts) {
     ref,
     repo,
     owner,
+    report,
   } = opts;
   const handler = HANDLERS.find(({ test }) => test(uri));
   if (!handler) {
@@ -59,7 +60,25 @@ async function reverseLookup(opts) {
     }
   }
 
-  const location = `${prefix}${documentPath}`;
+  // make author friendly
+  const friendlyPath = encodeURI(filename2url(decodeURI(documentPath)));
+  const location = `${prefix}${friendlyPath}`;
+
+  if (report) {
+    return {
+      'cache-control': 'no-store, private, must-revalidate',
+      statusCode: 200,
+      body: {
+        sourceUrl: uri.toString(),
+        webUrl: location,
+        unfriendlyWebUrl: `${prefix}${documentPath}`,
+      },
+      headers: {
+        'content-type': 'application/json',
+      },
+    };
+  }
+
   return {
     'cache-control': 'no-store, private, must-revalidate',
     statusCode: 302,

--- a/test/onedrive-reverse.test.js
+++ b/test/onedrive-reverse.test.js
@@ -161,6 +161,34 @@ describe('Onedrive Reverse Lookup Tests', () => {
     assert.equal(result.headers.location, 'https://theblog--adobe.hlx.page/ms/en/drafts/my-1-document.html');
   });
 
+  it('Returns resolve report for onedrive document with author friendly name', async function test() {
+    const { server } = this.polly;
+    server
+      .get('https://raw.githubusercontent.com/adobe/theblog/master/fstab.yaml')
+      .intercept((_, res) => res.status(200).send(fstab));
+    server
+      .post('https://login.windows.net/common/oauth2/token?api-version=1.0')
+      .intercept((_, res) => res.status(200).send(DEFAULT_AUTH));
+    server
+      .get('https://graph.microsoft.com/v1.0/sites/adobe.sharepoint.com:/sites/TheBlog:/lists/documents/items/31F3BD97-BD06-455B-939F-C594D1D92371')
+      .intercept((_, res) => res.status(200).send({
+        webUrl: 'https://adobe.sharepoint.com/sites/TheBlog/Shared%20Documents/theblog/en/drafts/My%201.%20D%C3%B6cument!.docx',
+      }));
+
+    const result = await main({
+      ...DEFAULT_PARAMS,
+      report: 'true',
+      lookup: 'https://adobe.sharepoint.com/:w:/r/sites/TheBlog/_layouts/15/Doc.aspx?sourcedoc=%7B31F3BD97-BD06-455B-939F-C594D1D92371%7D&file=My%201.%20D%C3%B6cument!.docx&action=default&mobileredirect=true',
+    });
+
+    assert.equal(result.statusCode, 200);
+    assert.deepEqual(result.body, {
+      sourceUrl: 'https://adobe.sharepoint.com/:w:/r/sites/TheBlog/_layouts/15/Doc.aspx?sourcedoc=%7B31F3BD97-BD06-455B-939F-C594D1D92371%7D&file=My%201.%20D%C3%B6cument!.docx&action=default&mobileredirect=true',
+      webUrl: 'https://theblog--adobe.hlx.page/ms/en/drafts/my-1-document.html',
+      unfriendlyWebUrl: 'https://theblog--adobe.hlx.page/ms/en/drafts/My%201.%20D%C3%B6cument!.html',
+    });
+  });
+
   it('Returns redirect for onedrive file', async function test() {
     const { server } = this.polly;
     server


### PR DESCRIPTION
fixes #227

Allows to specify a `report=true` request query param for a lookup request, that will return a info json instead of the 302 redirect.
