### PR TITLE
feat: forward last-modified header in response

### DIFF
--- a/test/fixtures/Excel-JSON-Integration-tests_3656940029/Get-JSON_3236052051/recording.har
+++ b/test/fixtures/Excel-JSON-Integration-tests_3656940029/Get-JSON_3236052051/recording.har
@@ -131,6 +131,10 @@
             {
               "name": "connection",
               "value": "keep-alive"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 14 Dec 2020 20:14:25 GMT"
             }
           ],
           "headersSize": 751,

--- a/test/onedrive-json.test.js
+++ b/test/onedrive-json.test.js
@@ -150,6 +150,7 @@ describe('Excel JSON Integration tests', () => {
     assert.deepEqual(res.headers, {
       'cache-control': 'no-store, private, must-revalidate',
       'content-type': 'application/json',
+      'last-modified': 'Mon, 14 Dec 2020 20:14:25 GMT',
       'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
       'surrogate-key': 'uZNkzznjLFRdaoIc',
       'x-source-location': '/drives/b!PpnkewKFAEaDTS6slvlVjh_3ih9lhEZMgYWwps6bPIWZMmLU5xGqS4uES8kIQZbH/items/01DJQLOW65RTXCQHBBGZFZ6IHSOUITJM2C',


### PR DESCRIPTION
Now that https://github.com/adobe/helix-data-embed can return a `Last-Modified` response header, have helix-content-proxy forward it to if available