### PR TITLE
fix: stop caching documents from OneDrive and Google

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -119,7 +119,7 @@ async function handle(opts) {
         'content-type': 'text/plain',
         'x-source-location': uri,
         // cache for Runtime (non-flushable)
-        'cache-control': 'no-cache, private',
+        'cache-control': 'no-store, private',
         'surrogate-key': utils.computeSurrogateKey(uri),
         'surrogate-control': immutable ? 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable' : 'max-age=60',
       },

--- a/src/github.js
+++ b/src/github.js
@@ -118,8 +118,9 @@ async function handle(opts) {
       headers: {
         'content-type': 'text/plain',
         'x-source-location': uri,
+        // cache for Runtime (non-flushable)
+        'cache-control': 'no-cache, private',
         'surrogate-key': utils.computeSurrogateKey(uri),
-        'cache-control': immutable ? 'max-age=30758400' : 'max-age=60',
         'surrogate-control': immutable ? 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable' : 'max-age=60',
       },
     });

--- a/src/google-json.js
+++ b/src/google-json.js
@@ -57,7 +57,7 @@ async function handleJSON(opts, params) {
           'x-source-location': sourceLocation,
           'surrogate-key': utils.computeSurrogateKey(sourceLocation),
           // cache for Runtime (non-flushable)
-          'cache-control': 'no-cache, private',
+          'cache-control': 'no-store, private',
           // cache for Fastly (flushable) – endless
           'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
         },
@@ -78,7 +78,7 @@ async function handleJSON(opts, params) {
       headers: {
         'content-type': 'text/plain',
         // cache for Runtime (non-flushable)
-        'cache-control': 'no-cache, private',
+        'cache-control': 'no-store, private',
       },
     });
   }

--- a/src/google-json.js
+++ b/src/google-json.js
@@ -57,7 +57,7 @@ async function handleJSON(opts, params) {
           'x-source-location': sourceLocation,
           'surrogate-key': utils.computeSurrogateKey(sourceLocation),
           // cache for Runtime (non-flushable)
-          'cache-control': 'no-store, private, must-revalidate',
+          'cache-control': 'no-cache, private',
           // cache for Fastly (flushable) – endless
           'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
         },
@@ -78,7 +78,7 @@ async function handleJSON(opts, params) {
       headers: {
         'content-type': 'text/plain',
         // cache for Runtime (non-flushable)
-        'cache-control': 'no-store, private, must-revalidate',
+        'cache-control': 'no-cache, private',
       },
     });
   }

--- a/src/google.js
+++ b/src/google.js
@@ -54,7 +54,7 @@ async function handle(opts) {
         'x-source-location': sourceLocation,
         'surrogate-key': utils.computeSurrogateKey(sourceLocation),
         // cache for Runtime (non-flushable)
-        'cache-control': 'no-cache, private',
+        'cache-control': 'no-store, private',
         // cache for Fastly (flushable) – endless
         'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
       },
@@ -65,7 +65,7 @@ async function handle(opts) {
     status: utils.propagateStatusCode(response.status),
     headers: {
       // cache for Runtime (non-flushable)
-      'cache-control': 'no-cache, private',
+      'cache-control': 'no-store, private',
     },
   });
 }

--- a/src/google.js
+++ b/src/google.js
@@ -53,6 +53,8 @@ async function handle(opts) {
         // if the backend does not provide a source location, use the URL
         'x-source-location': sourceLocation,
         'surrogate-key': utils.computeSurrogateKey(sourceLocation),
+        // cache for Runtime (non-flushable)
+        'cache-control': 'no-cache, private',
         // cache for Fastly (flushable) – endless
         'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
       },
@@ -62,7 +64,8 @@ async function handle(opts) {
   return new Response(body, {
     status: utils.propagateStatusCode(response.status),
     headers: {
-      'cache-control': 'max-age=60',
+      // cache for Runtime (non-flushable)
+      'cache-control': 'no-cache, private',
     },
   });
 }

--- a/src/google.js
+++ b/src/google.js
@@ -53,8 +53,6 @@ async function handle(opts) {
         // if the backend does not provide a source location, use the URL
         'x-source-location': sourceLocation,
         'surrogate-key': utils.computeSurrogateKey(sourceLocation),
-        // cache for Runtime (non-flushable) – 1 minute
-        'cache-control': 'max-age=60',
         // cache for Fastly (flushable) – endless
         'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
       },

--- a/src/onedrive-json.js
+++ b/src/onedrive-json.js
@@ -73,7 +73,7 @@ async function handleJSON(opts, params) {
           // enable fine-grained cache invalidation
           'surrogate-key': utils.computeSurrogateKey(sourceLocation),
           // cache for Runtime (non-flushable)
-          'cache-control': response.headers.get('cache-control'),
+          'cache-control': 'no-cache, private',
           // cache for Fastly (flushable) – endless
           'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
         };
@@ -105,7 +105,7 @@ async function handleJSON(opts, params) {
           // if the backend does not provide a source location, use the URL
           'x-source-location': url,
           // cache for Runtime (non-flushable)
-          'cache-control': 'max-age=60',
+          'cache-control': 'no-cache, private',
         },
       });
     }

--- a/src/onedrive-json.js
+++ b/src/onedrive-json.js
@@ -73,7 +73,7 @@ async function handleJSON(opts, params) {
           // enable fine-grained cache invalidation
           'surrogate-key': utils.computeSurrogateKey(sourceLocation),
           // cache for Runtime (non-flushable)
-          'cache-control': 'no-cache, private',
+          'cache-control': 'no-store, private',
           // cache for Fastly (flushable) – endless
           'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
         };
@@ -105,7 +105,7 @@ async function handleJSON(opts, params) {
           // if the backend does not provide a source location, use the URL
           'x-source-location': url,
           // cache for Runtime (non-flushable)
-          'cache-control': 'no-cache, private',
+          'cache-control': 'no-store, private',
         },
       });
     }

--- a/src/onedrive.js
+++ b/src/onedrive.js
@@ -51,7 +51,7 @@ async function handle(opts) {
         'x-source-location': response.headers.get('x-source-location'),
         'surrogate-key': utils.computeSurrogateKey(response.headers.get('x-source-location')),
         // cache for Runtime (non-flushable)
-        'cache-control': 'no-cache, private',
+        'cache-control': 'no-store, private',
         // cache for Fastly (flushable) – endless
         'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
       },

--- a/src/onedrive.js
+++ b/src/onedrive.js
@@ -50,8 +50,6 @@ async function handle(opts) {
         // if the backend does not provide a source location, use the URL
         'x-source-location': response.headers.get('x-source-location'),
         'surrogate-key': utils.computeSurrogateKey(response.headers.get('x-source-location')),
-        // cache for Runtime (non-flushable) – 1 minute
-        'cache-control': 'max-age=60',
         // cache for Fastly (flushable) – endless
         'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
       },

--- a/src/onedrive.js
+++ b/src/onedrive.js
@@ -50,6 +50,8 @@ async function handle(opts) {
         // if the backend does not provide a source location, use the URL
         'x-source-location': response.headers.get('x-source-location'),
         'surrogate-key': utils.computeSurrogateKey(response.headers.get('x-source-location')),
+        // cache for Runtime (non-flushable)
+        'cache-control': 'no-cache, private',
         // cache for Fastly (flushable) – endless
         'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
       },

--- a/test/dev/index.js
+++ b/test/dev/index.js
@@ -9,6 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+/* eslint-disable no-console */
 
 const { Request } = require('@adobe/helix-fetch');
 const { main } = require('../../src/index.js');

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -120,7 +120,7 @@ describe('GitHub Integration Tests', () => {
 
     assert.equal(result.statusCode, 200);
     assert.equal(result.body.indexOf('# Markdown Features in Project Helix'), 0);
-    assert.equal(result.headers['cache-control'], 'no-cache, private');
+    assert.equal(result.headers['cache-control'], 'no-store, private');
     assert.equal(result.headers['surrogate-control'], 'max-age=60');
   });
 
@@ -135,7 +135,7 @@ describe('GitHub Integration Tests', () => {
     assert.equal(result.statusCode, 200);
     assert.equal(result.body.indexOf('---'), 0);
     assert.equal(result.headers['x-source-location'], 'https://raw.githubusercontent.com/adobe/theblog/04f19cd404780382c5a53d0cf64fbe4b0b827eff/index.md');
-    assert.equal(result.headers['cache-control'], 'no-cache, private');
+    assert.equal(result.headers['cache-control'], 'no-store, private');
     assert.equal(result.headers['surrogate-control'], 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable');
   });
 

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -120,7 +120,7 @@ describe('GitHub Integration Tests', () => {
 
     assert.equal(result.statusCode, 200);
     assert.equal(result.body.indexOf('# Markdown Features in Project Helix'), 0);
-    assert.equal(result.headers['cache-control'], 'max-age=60');
+    assert.equal(result.headers['cache-control'], 'no-cache, private');
     assert.equal(result.headers['surrogate-control'], 'max-age=60');
   });
 
@@ -135,7 +135,7 @@ describe('GitHub Integration Tests', () => {
     assert.equal(result.statusCode, 200);
     assert.equal(result.body.indexOf('---'), 0);
     assert.equal(result.headers['x-source-location'], 'https://raw.githubusercontent.com/adobe/theblog/04f19cd404780382c5a53d0cf64fbe4b0b827eff/index.md');
-    assert.equal(result.headers['cache-control'], 'max-age=30758400');
+    assert.equal(result.headers['cache-control'], 'no-cache, private');
     assert.equal(result.headers['surrogate-control'], 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable');
   });
 

--- a/test/google.test.js
+++ b/test/google.test.js
@@ -98,7 +98,7 @@ describe('Google Integration Tests', () => {
 
     assert.equal(result.statusCode, 404);
     assert.equal(result.body, 'error while converting document');
-    assert.equal(result.headers['cache-control'], 'no-cache, private');
+    assert.equal(result.headers['cache-control'], 'no-store, private');
   }).timeout(5000);
 });
 

--- a/test/google.test.js
+++ b/test/google.test.js
@@ -98,7 +98,7 @@ describe('Google Integration Tests', () => {
 
     assert.equal(result.statusCode, 404);
     assert.equal(result.body, 'error while converting document');
-    assert.equal(result.headers['cache-control'], 'max-age=60');
+    assert.equal(result.headers['cache-control'], 'no-cache, private');
   }).timeout(5000);
 });
 

--- a/test/google.test.js
+++ b/test/google.test.js
@@ -58,7 +58,6 @@ describe('Google Integration Tests', () => {
     assert.equal(result.statusCode, 200);
     assert.equal(result.body, '# This is nothing\n\n...yet\n');
     assert.equal(result.headers['x-source-location'], '1GIItS1y0YXTySslLGqJZUFxwFH1DPlSg3R7ybYY3ATE');
-    assert.equal(result.headers['cache-control'], 'max-age=60');
     assert.equal(result.headers['surrogate-control'], 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable');
     assert.equal(result.headers.vary, 'x-ow-version-lock');
   }).timeout(5000);
@@ -80,7 +79,6 @@ describe('Google Integration Tests', () => {
     assert.equal(result.statusCode, 200);
     assert.equal(result.body, '# This is nothing\n\n...yet\n');
     assert.equal(result.headers['x-source-location'], '1GIItS1y0YXTySslLGqJZUFxwFH1DPlSg3R7ybYY3ATE');
-    assert.equal(result.headers['cache-control'], 'max-age=60');
     assert.equal(result.headers['surrogate-control'], 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable');
   }).timeout(5000);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -187,7 +187,7 @@ mountpoints:
         ],
       },
       headers: {
-        'cache-control': 'no-cache, private',
+        'cache-control': 'no-store, private',
         'content-type': 'application/json',
         'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
         'surrogate-key': 'ERUhf9+V6/T5sTc/',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -187,7 +187,7 @@ mountpoints:
         ],
       },
       headers: {
-        'cache-control': 'null',
+        'cache-control': 'no-cache, private',
         'content-type': 'application/json',
         'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
         'surrogate-key': 'ERUhf9+V6/T5sTc/',

--- a/test/onedrive-json.test.js
+++ b/test/onedrive-json.test.js
@@ -167,7 +167,7 @@ describe('Excel JSON Integration tests', () => {
 
     assert.equal(res.statusCode, 200);
     assert.deepEqual(res.headers, {
-      'cache-control': 'no-cache, private',
+      'cache-control': 'no-store, private',
       'content-type': 'application/json',
       'last-modified': 'Mon, 14 Dec 2020 20:14:25 GMT',
       'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
@@ -232,7 +232,7 @@ describe('Excel JSON Integration tests', () => {
 
     assert.equal(res.statusCode, 200);
     assert.deepEqual(res.headers, {
-      'cache-control': 'no-cache, private',
+      'cache-control': 'no-store, private',
       'content-type': 'application/json',
       'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
       'surrogate-key': 'IEPk2TBbQwWp8mOq',

--- a/test/onedrive-json.test.js
+++ b/test/onedrive-json.test.js
@@ -167,7 +167,7 @@ describe('Excel JSON Integration tests', () => {
 
     assert.equal(res.statusCode, 200);
     assert.deepEqual(res.headers, {
-      'cache-control': 'no-store, private, must-revalidate',
+      'cache-control': 'no-cache, private',
       'content-type': 'application/json',
       'last-modified': 'Mon, 14 Dec 2020 20:14:25 GMT',
       'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
@@ -232,7 +232,7 @@ describe('Excel JSON Integration tests', () => {
 
     assert.equal(res.statusCode, 200);
     assert.deepEqual(res.headers, {
-      'cache-control': 'no-store, private, must-revalidate',
+      'cache-control': 'no-cache, private',
       'content-type': 'application/json',
       'surrogate-control': 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable',
       'surrogate-key': 'IEPk2TBbQwWp8mOq',

--- a/test/onedrive.test.js
+++ b/test/onedrive.test.js
@@ -48,7 +48,6 @@ describe('OneDrive Integration Tests', () => {
     assert.equal(result.statusCode, 200);
     assert.equal(result.body.indexOf('# The Blog | Welcome to Adobe Blog'), 0);
     assert.equal(result.headers['x-source-location'], '/drives/b!PpnkewKFAEaDTS6slvlVjh_3ih9lhEZMgYWwps6bPIWZMmLU5xGqS4uES8kIQZbH/items/01DJQLOW44UHM362CKX5GYMQO2F4JIHSEV');
-    assert.equal(result.headers['cache-control'], 'max-age=60');
     assert.equal(result.headers['surrogate-control'], 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable');
     assert.equal(result.headers.vary, 'x-ow-version-lock');
   }).timeout(5000);
@@ -70,7 +69,6 @@ describe('OneDrive Integration Tests', () => {
     assert.equal(result.statusCode, 200);
     assert.equal(result.body.indexOf('# The Blog | Welcome to Adobe Blog'), 0);
     assert.equal(result.headers['x-source-location'], '/drives/b!PpnkewKFAEaDTS6slvlVjh_3ih9lhEZMgYWwps6bPIWZMmLU5xGqS4uES8kIQZbH/items/01DJQLOW44UHM362CKX5GYMQO2F4JIHSEV');
-    assert.equal(result.headers['cache-control'], 'max-age=60');
     assert.equal(result.headers['surrogate-control'], 'max-age=30758400, stale-while-revalidate=30758400, stale-if-error=30758400, immutable');
   }).timeout(5000);
 


### PR DESCRIPTION
With the switch to caching documents in Fastly, we no longer need to cache the output of `content-proxy` as well, see https://github.com/adobe/helix-pages/pull/720