### PR TITLE
Implement Penalty Box for OneDrive

### DIFF
--- a/src/penalty-box.js
+++ b/src/penalty-box.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const LRU = require('lru-cache');
+
+class PenaltyBox {
+  constructor() {
+    this.box = new LRU({ max: 1000, maxAge: 30 * 1000 });
+  }
+
+  foul(owner, repo) {
+    this.box.set(`${owner}/${repo}`, new Date());
+  }
+
+  ready(owner, repo) {
+    return !this.box.peek(`${owner}/${repo}`);
+  }
+}
+
+module.exports = PenaltyBox;

--- a/src/penalty-box.js
+++ b/src/penalty-box.js
@@ -12,8 +12,12 @@
 const LRU = require('lru-cache');
 
 class PenaltyBox {
-  constructor() {
-    this.box = new LRU({ max: 1000, maxAge: 30 * 1000 });
+  /**
+   * Creates a new penalty box with a given timeout
+   * @param {Number} timeout timeout in seconds
+   */
+  constructor(timeout = 30) {
+    this.box = new LRU({ max: 1000, maxAge: timeout * 1000 });
   }
 
   foul(owner, repo) {

--- a/test/onedrive.test.js
+++ b/test/onedrive.test.js
@@ -52,6 +52,36 @@ describe('OneDrive Integration Tests', () => {
     assert.equal(result.headers.vary, 'x-ow-version-lock');
   }).timeout(5000);
 
+  it.only('Handles 429s from Sharepoint', async function onedrive429() {
+    const { server } = this.polly;
+
+    server
+      .get('https://raw.githubusercontent.com/adobe/spark-website/cb8a0dc5d9d89b800835166783e4130451d3c6a5/fstab.yaml')
+      .intercept((_, res) => res.status(200).send(fstab));
+
+    server
+      .get('https://adobeioruntime.net/api/v1/web/helix/helix-services/word2md@v2')
+      .intercept((_, res) => res.status(429).send('Too many requests'));
+
+    const result1 = await index({
+      owner: 'adobe',
+      repo: 'spark-website',
+      ref: 'cb8a0dc5d9d89b800835166783e4130451d3c6a5',
+      path: '/index.md',
+    });
+
+    assert.equal(result1.statusCode, 503, 'First response should be a 503 due to backend 429');
+
+    const result2 = await index({
+      owner: 'adobe',
+      repo: 'spark-website',
+      ref: 'cb8a0dc5d9d89b800835166783e4130451d3c6a5',
+      path: '/index.md',
+    });
+
+    assert.equal(result2.statusCode, 429, 'Second response should be a preemptive 429 to preserve rate limits for other clients');
+  }).timeout(5000);
+
   it('Retrieves Document mounted md from Word', async function okOnedrive() {
     const { server } = this.polly;
 

--- a/test/onedrive.test.js
+++ b/test/onedrive.test.js
@@ -52,7 +52,7 @@ describe('OneDrive Integration Tests', () => {
     assert.equal(result.headers.vary, 'x-ow-version-lock');
   }).timeout(5000);
 
-  it.only('Handles 429s from Sharepoint', async function onedrive429() {
+  it('Handles 429s from Sharepoint', async function onedrive429() {
     const { server } = this.polly;
 
     server

--- a/test/penalty-box.test.js
+++ b/test/penalty-box.test.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+const assert = require('assert');
+const PenaltyBox = require('../src/penalty-box');
+
+const sleep = (s) => new Promise((res) => setTimeout(res, s * 1000));
+
+describe('Test Penalty Box', () => {
+  it('No foul, no harm', async () => {
+    const box = new PenaltyBox();
+    assert.ok(box.ready('player1'));
+    assert.ok(box.ready('player2'));
+  }).timeout(120000);
+
+  it('Go into the box', async () => {
+    const box = new PenaltyBox();
+    assert.ok(box.ready('player1'));
+    assert.ok(box.ready('player2'));
+
+    box.foul('player1');
+    await sleep(11);
+    console.log('tick');
+    assert.ok(!box.ready('player1'));
+    assert.ok(box.ready('player2'));
+    await sleep(11);
+    console.log('tick');
+    assert.ok(!box.ready('player1'));
+    assert.ok(box.ready('player2'));
+    await sleep(11);
+    console.log('tick');
+    assert.ok(box.ready('player1'));
+    assert.ok(box.ready('player2'));
+  }).timeout(120000);
+
+  it('Two games at once', async () => {
+    const box = new PenaltyBox();
+
+    const game1 = async () => {
+      await sleep(12);
+      console.log('tick');
+      box.foul('player1');
+      await sleep(12);
+      console.log('tick');
+      await sleep(12);
+      console.log('tick');
+      box.foul('player2');
+      await sleep(12);
+      console.log('tick');
+      await sleep(12);
+      console.log('tick');
+    };
+
+    const game2 = async () => {
+      await sleep(9);
+      console.log('tock');
+      box.foul('player2');
+      await sleep(9);
+      console.log('tock');
+      await sleep(9);
+      console.log('tock');
+      await sleep(9);
+      console.log('tock');
+      await sleep(9);
+      console.log('tock');
+      box.foul('player1');
+      await sleep(9);
+      console.log('tock');
+    };
+
+    const results = [];
+
+    const check = async () => {
+      for (let i = 0; i < 80; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(1);
+        results.push({
+          iteration: i,
+          player1: box.ready('player1'),
+          player2: box.ready('player2'),
+        });
+      }
+    };
+    await Promise.all([game1(), game2(), check()]);
+
+    console.table(results);
+
+    assert.deepStrictEqual(results[0], {
+      iteration: 0,
+      player1: true,
+      player2: true,
+    });
+
+    assert.deepStrictEqual(results[30], {
+      iteration: 30,
+      player1: false,
+      player2: false,
+    });
+
+    assert.deepStrictEqual(results[70], {
+      iteration: 70,
+      player1: false,
+      player2: true,
+    });
+
+    assert.deepStrictEqual(results[75], {
+      iteration: 75,
+      player1: true,
+      player2: true,
+    });
+  }).timeout(120000);
+});

--- a/test/penalty-box.test.js
+++ b/test/penalty-box.test.js
@@ -23,64 +23,64 @@ describe('Test Penalty Box', () => {
   }).timeout(120000);
 
   it('Go into the box', async () => {
-    const box = new PenaltyBox();
+    const box = new PenaltyBox(3);
     assert.ok(box.ready('player1'));
     assert.ok(box.ready('player2'));
 
     box.foul('player1');
-    await sleep(11);
+    await sleep(1);
     console.log('tick');
     assert.ok(!box.ready('player1'));
     assert.ok(box.ready('player2'));
-    await sleep(11);
+    await sleep(1);
     console.log('tick');
     assert.ok(!box.ready('player1'));
     assert.ok(box.ready('player2'));
-    await sleep(11);
+    await sleep(1);
     console.log('tick');
     assert.ok(box.ready('player1'));
     assert.ok(box.ready('player2'));
   }).timeout(120000);
 
   it('Two games at once', async () => {
-    const box = new PenaltyBox();
+    const box = new PenaltyBox(3);
 
     const game1 = async () => {
-      await sleep(12);
+      await sleep(2);
       console.log('tick');
       box.foul('player1');
-      await sleep(12);
+      await sleep(2);
       console.log('tick');
-      await sleep(12);
+      await sleep(2);
       console.log('tick');
       box.foul('player2');
-      await sleep(12);
+      await sleep(2);
       console.log('tick');
-      await sleep(12);
+      await sleep(2);
       console.log('tick');
     };
 
     const game2 = async () => {
-      await sleep(9);
+      await sleep(2);
       console.log('tock');
+      await sleep(1);
       box.foul('player2');
-      await sleep(9);
       console.log('tock');
-      await sleep(9);
+      await sleep(1);
       console.log('tock');
-      await sleep(9);
+      await sleep(1);
       console.log('tock');
-      await sleep(9);
+      await sleep(1);
       console.log('tock');
       box.foul('player1');
-      await sleep(9);
+      await sleep(1);
       console.log('tock');
     };
 
     const results = [];
 
     const check = async () => {
-      for (let i = 0; i < 80; i += 1) {
+      for (let i = 0; i < 15; i += 1) {
         // eslint-disable-next-line no-await-in-loop
         await sleep(1);
         results.push({
@@ -100,20 +100,20 @@ describe('Test Penalty Box', () => {
       player2: true,
     });
 
-    assert.deepStrictEqual(results[30], {
-      iteration: 30,
-      player1: false,
-      player2: false,
-    });
-
-    assert.deepStrictEqual(results[70], {
-      iteration: 70,
+    assert.deepStrictEqual(results[1], {
+      iteration: 1,
       player1: false,
       player2: true,
     });
 
-    assert.deepStrictEqual(results[75], {
-      iteration: 75,
+    assert.deepStrictEqual(results[2], {
+      iteration: 2,
+      player1: false,
+      player2: false,
+    });
+
+    assert.deepStrictEqual(results[8], {
+      iteration: 8,
       player1: true,
       player2: true,
     });


### PR DESCRIPTION
- feat(penalty): add penalty box to prevent 429 overload
- feat(onedrive): guard word2md with penalty box to prevent rate limit exhaustion

This is a quick fix for #377 and should be seen as a bridge until #376 has been implemented and rolled out across all sites.

It prevents one site to exhaust the rate limit for all other sites