### PR TITLE
feat(proxy): add multi user support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@adobe/helix-fetch": "2.2.0",
         "@adobe/helix-onedrive-support": "4.0.5",
-        "@adobe/helix-shared": "7.24.0",
+        "@adobe/helix-shared": "7.25.0",
         "@adobe/helix-status": "9.1.6",
         "@adobe/helix-universal": "1.0.0",
         "@adobe/helix-universal-logger": "1.0.2",
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@adobe/helix-shared": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared/-/helix-shared-7.24.0.tgz",
-      "integrity": "sha512-hCMPZaPzZT/GVZ2OtOH96JnQK3CnSw5eqV2bh1/xvlkdtMQGvyEYU6DL49/vtZASHdobscbG51/1b8T1e6M8hQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared/-/helix-shared-7.25.0.tgz",
+      "integrity": "sha512-DQmGmdb10QnzjCR1jvx1m1Q5+NNwFitN6YYnz6ozvTAsCI4weTNFzxc5UDSt3REJ49TJXiY8BW8X8za0ZSB2IQ==",
       "dependencies": {
         "@adobe/helix-fetch": "2.2.0",
         "@adobe/helix-log": "5.0.3",
@@ -17922,9 +17922,9 @@
       }
     },
     "@adobe/helix-shared": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared/-/helix-shared-7.24.0.tgz",
-      "integrity": "sha512-hCMPZaPzZT/GVZ2OtOH96JnQK3CnSw5eqV2bh1/xvlkdtMQGvyEYU6DL49/vtZASHdobscbG51/1b8T1e6M8hQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared/-/helix-shared-7.25.0.tgz",
+      "integrity": "sha512-DQmGmdb10QnzjCR1jvx1m1Q5+NNwFitN6YYnz6ozvTAsCI4weTNFzxc5UDSt3REJ49TJXiY8BW8X8za0ZSB2IQ==",
       "requires": {
         "@adobe/helix-fetch": "2.2.0",
         "@adobe/helix-log": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@adobe/helix-fetch": "2.2.0",
     "@adobe/helix-onedrive-support": "4.0.5",
-    "@adobe/helix-shared": "7.24.0",
+    "@adobe/helix-shared": "7.25.0",
     "@adobe/helix-status": "9.1.6",
     "@adobe/helix-universal": "1.0.0",
     "@adobe/helix-universal-logger": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-content-proxy",
-  "version": "2.13.3",
+  "version": "2.13.3-test",
   "private": true,
   "description": "Helix Content Proxy",
   "main": "src/index.js",

--- a/src/credentials.js
+++ b/src/credentials.js
@@ -84,7 +84,7 @@ function getCredentials(log, mp, key) {
     const text = credentials[i];
     if (text) {
       try {
-        return JSON.parse(decrypt(key, text, log));
+        return JSON.parse(decrypt(key, text));
       } catch (e) {
         log.warn(`decrypted credentials in ${mp.path}.credentials[${i}] not valid: ${e.message}.`);
       }

--- a/src/credentials.js
+++ b/src/credentials.js
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const crypto = require('crypto');
+
+const ALGO = 'aes-256-gcm';
+const SALT_SIZE = 8;
+const IV_SIZE = 12;
+const AUTH_TAG_SIZE = 16;
+
+function deriveKey(key, salt) {
+  return crypto.pbkdf2Sync(key, salt, 100000, 32, 'sha512');
+}
+
+/**
+ * Provides an AES-GCM symmetric encryption using a key derivation from a generic password.
+ * The resulting string is a base64 encoded buffer of the salt, iv, auth and encrypted text.
+ * Using GCM has the advantage over plain AES, that the validity of the key can be verified.
+ * (similar to a AES + HMAC approach).
+ *
+ * result = base64( salt | iv | auth | enc )
+ *
+ * @param {string} key encryption key / password
+ * @param {string} text Plain text to encrypt
+ * @return {string} base64 encoded digest.
+ */
+function encrypt(key, text) {
+  const salt = crypto.randomBytes(SALT_SIZE);
+  const iv = crypto.randomBytes(IV_SIZE);
+  const derivedKey = deriveKey(key, salt);
+  const cipher = crypto.createCipheriv(ALGO, derivedKey, iv);
+
+  const data = [salt, iv, null];
+  data.push(cipher.update(text, 'utf8'));
+  data.push(cipher.final());
+  data[2] = cipher.getAuthTag();
+  return Buffer.concat(data).toString('base64');
+}
+
+/**
+ * Decrypts a AES-GCM encrypted digest.
+ * @param {string} key encryption key / password
+ * @param {string} digest the encrypted text
+ * @returns {string} the plain text
+ * @throws an error if the given key cannot decrypt the digest.
+ */
+function decrypt(key, digest) {
+  const data = Buffer.from(digest, 'base64');
+  const salt = data.slice(0, SALT_SIZE);
+  const iv = data.slice(SALT_SIZE, SALT_SIZE + IV_SIZE);
+  const authTag = data.slice(SALT_SIZE + IV_SIZE, SALT_SIZE + IV_SIZE + AUTH_TAG_SIZE);
+  const enc = data.slice(SALT_SIZE + IV_SIZE + AUTH_TAG_SIZE);
+
+  const derivedKey = deriveKey(key, salt);
+  const decipher = crypto.createDecipheriv(ALGO, derivedKey, iv);
+  decipher.setAuthTag(authTag);
+
+  let str = decipher.update(enc, null, 'utf8');
+  str += decipher.final('utf8');
+  return str;
+}
+
+/**
+ * Returns the first valid credentials from the given mountpoint or null.
+ * @param {logger} log a logger
+ * @param {MountPoint} mp a fstab mountpoint
+ * @param {string} key encryption key
+ * @returns {object} the credentials object or null.
+ */
+function getCredentials(log, mp, key) {
+  let { credentials = [] } = mp;
+  if (!Array.isArray(credentials)) {
+    credentials = [credentials];
+  }
+  for (let i = 0; i < credentials.length; i += 1) {
+    const text = credentials[i];
+    if (text) {
+      try {
+        return JSON.parse(decrypt(key, text, log));
+      } catch (e) {
+        log.warn(`decrypted credentials in ${mp.path}.credentials[${i}] not valid: ${e.message}.`);
+      }
+    }
+  }
+  return null;
+}
+
+module.exports = {
+  encrypt,
+  decrypt,
+  getCredentials,
+};

--- a/src/github-edit-link.js
+++ b/src/github-edit-link.js
@@ -14,6 +14,11 @@ function test(mp) {
   return !mp;
 }
 
+/**
+ * Performs a lookup from the edit url to the source document.
+ * @param {EditLookupOptions} opts options
+ * @returns {Promise<string>} the resolved url
+ */
 async function getEditUrl(opts) {
   const {
     owner, repo, ref, resourcePath,

--- a/src/github.js
+++ b/src/github.js
@@ -64,8 +64,7 @@ const fetchFSTabCached = cache(fetchFSTabUncached, {
     owner,
     repo,
     ref,
-    options && options.headers && options.headers.authorization
-      ? options.headers.authorization : undefined,
+    options && options.headers && options.headers.authorization,
   ].join()),
 });
 

--- a/src/github.js
+++ b/src/github.js
@@ -33,13 +33,9 @@ async function computeGithubURI(root, owner, repo, ref = 'main', path) {
 
 /**
  * Fetches an FSTab file from a GitHub repository
- * @param {object} opts options
- * @param {string} opts.root base URL for GitHub
- * @param {string} opts.owner GitHub owner or org
- * @param {string} opts.repo GitHub repository
- * @param {string} opts.ref GitHub ref
- * @param {object} opts.log Helix-Log instance
- * @param {object} opts.options HTTP request options
+ * @param {FetchFSTabOptions} opts options
+ * @returns {Promise<string>} the fstab
+ * @throws {Error} if the fstab cannot be retrieved
  */
 async function fetchFSTabUncached(opts) {
   const {
@@ -68,8 +64,8 @@ const fetchFSTabCached = cache(fetchFSTabUncached, {
     owner,
     repo,
     ref,
-    options && options.headers && options.headers.Authorization
-      ? options.headers.Authorization : undefined,
+    options && options.headers && options.headers.authorization
+      ? options.headers.authorization : undefined,
   ].join()),
 });
 
@@ -78,14 +74,19 @@ function isImmutable(ref) {
 }
 
 /**
+ * Fetches the fstab from the github repository.
+ * @param {FetchFSTabOptions} opts the options
+ * @returns {Promise<string>} the fstab
+ * @throws {Error} if the fstab cannot be retrieved
+ */
+function fetchFSTab(opts) {
+  return fetchFSTabCached(opts);
+}
+
+/**
  * Retrieves a file from GitHub
- * @param {object} opts
- * @param {string} opts.githubRootPath base URL for raw.githubusercontent.com
- * @param {string} opts.owner GitHub owner or org
- * @param {string} opts.repo GitHub repository
- * @param {string} opts.ref GitHub ref
- * @param {object} opts.log Helix-Log instance
- * @param {object} opts.options HTTP fetch options
+ * @param {GithubHandlerOptions} opts the options
+ * @return {Promise<Response>} the http response
  */
 async function handle(opts) {
   const {
@@ -112,7 +113,8 @@ async function handle(opts) {
       headers,
     });
   }
-  return errorResponse(log, -response.status, `Unable to fetch ${uri} (${response.status}) from GitHub`);
+  const authReason = options.headers.authorization ? '(authenticated)' : '(not authenticated)';
+  return errorResponse(log, -response.status, `Unable to fetch ${uri} (${response.status}) from GitHub ${authReason}`);
 }
 
 function canhandle(mp) {
@@ -120,4 +122,4 @@ function canhandle(mp) {
   return !mp || mp.type === 'github';
 }
 
-module.exports = { canhandle, handle, fetchFSTab: fetchFSTabCached };
+module.exports = { canhandle, handle, fetchFSTab };

--- a/src/google-edit-link.js
+++ b/src/google-edit-link.js
@@ -20,6 +20,10 @@ async function getEditUrl(opts) {
     mp, log, ext, options,
   } = opts;
 
+  if (options.credentials) {
+    // todo: respect credentials
+  }
+
   const docId = await getIdFromPath(mp.relPath.substring(1), mp.id, log, options);
   if (!docId) {
     return '';

--- a/src/google-edit-link.js
+++ b/src/google-edit-link.js
@@ -15,14 +15,19 @@ function test(mp) {
   return mp && mp.type === 'google';
 }
 
+/**
+ * Performs a lookup from the edit url to the source document.
+ * @param {EditLookupOptions} opts options
+ * @returns {Promise<string>} the resolved url
+ */
 async function getEditUrl(opts) {
   const {
     mp, log, ext, options,
   } = opts;
 
-  if (options.credentials) {
-    // todo: respect credentials
-  }
+  // if (options.credentials) {
+  // todo: respect credentials
+  // }
 
   const docId = await getIdFromPath(mp.relPath.substring(1), mp.id, log, options);
   if (!docId) {

--- a/src/google-json.js
+++ b/src/google-json.js
@@ -16,14 +16,20 @@ const {
 } = require('./utils');
 const { getIdFromPath } = require('./google-helpers.js');
 
+/**
+ * Fetches an google sheet from the external source.
+ * @param {ExternalHandlerOptions} opts the options.
+ * @param {object} params original request params
+ * @returns {Promise<Response>} a http response
+ */
 async function handleJSON(opts, params) {
   const {
     mp, log, options, resolver,
   } = opts;
 
-  if (options.credentials) {
-    // todo: respect credentials
-  }
+  // if (options.credentials) {
+  //   // todo: respect credentials
+  // }
 
   try {
     const sheetId = await getIdFromPath(mp.relPath.substring(1), mp.id, log, options);

--- a/src/google-json.js
+++ b/src/google-json.js
@@ -21,6 +21,10 @@ async function handleJSON(opts, params) {
     mp, log, options, resolver,
   } = opts;
 
+  if (options.credentials) {
+    // todo: respect credentials
+  }
+
   try {
     const sheetId = await getIdFromPath(mp.relPath.substring(1), mp.id, log, options);
 

--- a/src/google-reverse.js
+++ b/src/google-reverse.js
@@ -45,6 +45,10 @@ async function reverseLookup(opts) {
   });
   log.debug('mount roots', roots);
 
+  if (options.githubToken) {
+    // todo: respect credentials
+  }
+
   const path = await getPathFromId(id, roots, {
     log,
     ...options,

--- a/src/google-reverse.js
+++ b/src/google-reverse.js
@@ -17,6 +17,11 @@ function test(uri) {
     || uri.protocol === 'gdrive:';
 }
 
+/**
+ * Performs a reverse lookup from an edit url to a website url.
+ * @param {ReverseLookupOptions} opts the options.
+ * @returns {Promise<string>} the website url
+ */
 async function reverseLookup(opts) {
   const {
     mount,
@@ -45,9 +50,9 @@ async function reverseLookup(opts) {
   });
   log.debug('mount roots', roots);
 
-  if (options.githubToken) {
-    // todo: respect credentials
-  }
+  // if (options.githubToken) {
+  //   // todo: respect credentials
+  // }
 
   const path = await getPathFromId(id, roots, {
     log,

--- a/src/google-sitemap.js
+++ b/src/google-sitemap.js
@@ -14,12 +14,17 @@ const { utils } = require('@adobe/helix-shared');
 const { getFile, getIdFromPath } = require('./google-helpers.js');
 const { errorResponse } = require('./utils.js');
 
+/**
+ * Fetches an google sheet with sitemap data from the external source.
+ * @param {ExternalHandlerOptions} opts the options.
+ * @returns {Promise<Response>} a http response
+ */
 async function handleSitemapXML(opts) {
   const { mp, log, options } = opts;
 
-  if (options.credentials) {
-    // todo: respect credentials
-  }
+  // if (options.credentials) {
+  //   // todo: respect credentials
+  // }
 
   const path = `${mp.relPath.substring(1)}.xml`;
   try {

--- a/src/google-sitemap.js
+++ b/src/google-sitemap.js
@@ -17,6 +17,10 @@ const { errorResponse } = require('./utils.js');
 async function handleSitemapXML(opts) {
   const { mp, log, options } = opts;
 
+  if (options.credentials) {
+    // todo: respect credentials
+  }
+
   const path = `${mp.relPath.substring(1)}.xml`;
   try {
     log.info(`fetch sitemap from gdrive: ${path}`);

--- a/src/google.js
+++ b/src/google.js
@@ -16,15 +16,9 @@ const { handleSitemapXML } = require('./google-sitemap');
 const { fetch, getFetchOptions, errorResponse } = require('./utils');
 
 /**
- * Retrieves a file from OneDrive
- * @param {object} opts options
- * @param {object} opts.mp the mountpoint as defined by helix-shared
- * @param {string} opts.owner the GitHub org or username
- * @param {string} opts.repo the GitHub repository
- * @param {string} opts.ref the GitHub ref
- * @param {object} opts.log a Helix-Log instance
- * @param {object} opts.options Helix Fetch options
- * @param {Resolver} opts.resolver Action name resolver
+ * Retrieves a file from google drive
+ * @param {ExternalHandlerOptions} opts the options
+ * @return {Promise<Response>} the http response
  */
 async function handle(opts) {
   const {
@@ -35,8 +29,6 @@ async function handle(opts) {
     name: 'gdocs2md',
     version: 'v2',
   });
-
-
 
   url.searchParams.append('path', mp.relPath);
   url.searchParams.append('rootId', mp.id);

--- a/src/google.js
+++ b/src/google.js
@@ -36,6 +36,8 @@ async function handle(opts) {
     version: 'v2',
   });
 
+
+
   url.searchParams.append('path', mp.relPath);
   url.searchParams.append('rootId', mp.id);
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { Resolver } from '@adobe/helix-universal'
+
+declare interface Logger {}
+declare interface MountConfig {}
+declare interface MountPoint {}
+
+/**
+ * options for github requests
+ */
+declare interface GithubOptions {
+  cache:string;
+  fetchTimeout:number;
+  headers:object;
+}
+
+/**
+ * options for external (service) requests
+ */
+declare interface ExternalOptions {
+  cache:string;
+  fetchTimeout:string;
+  headers:object;
+  namespace:string;
+  githubToken:string;
+
+  GOOGLE_DOCS2MD_CLIENT_ID:string;
+  GOOGLE_DOCS2MD_CLIENT_SECRET:string;
+  GOOGLE_DOCS2MD_REFRESH_TOKEN:string;
+  AZURE_WORD2MD_CLIENT_ID:string;
+  AZURE_WORD2MD_CLIENT_SECRET:string;
+  AZURE_HELIX_USER:string;
+  AZURE_HELIX_PASSWORD:string;
+}
+
+declare interface FetchFSTabOptions {
+  /**
+   * github root path
+   */
+  root:string;
+
+  owner:string;
+  repo:string;
+  ref:string;
+
+  log:Logger;
+  options:GithubOptions;
+}
+
+declare interface ReverseLookupOptions {
+  mount:MountConfig;
+  options:ExternalOptions;
+  uri:URL;
+  prefix:string;
+  owner:string;
+  repo:string;
+  ref:string;
+  report:boolean;
+  log:Logger;
+}
+
+declare interface EditLookupOptions {
+  mount:MountConfig;
+  options:ExternalOptions;
+  owner:string;
+  repo:string;
+  ref:string;
+  path:string;
+  log:Logger;
+}
+
+declare interface HandlerOptions {
+  mp:MountPoint;
+  githubRootPath:string;
+  owner:string;
+  repo:string;
+  ref:string;
+  path:string;
+  log:Logger;
+  resolver:Resolver;
+}
+
+declare interface GithubHandlerOptions extends HandlerOptions {
+  options:GithubOptions;
+}
+
+declare interface ExternalHandlerOptions extends HandlerOptions {
+  options:ExternalOptions;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -100,11 +100,12 @@ async function main(req, context) {
           headers[header.toLocaleLowerCase()] = req.headers.get(header);
         }
         return headers;
-      }, {
-        // pass on authorization token
-        authorization: gitHubToken ? `token ${gitHubToken}` : undefined,
-      }),
+      }, {}),
     };
+    if (gitHubToken) {
+      // pass on authorization token
+      githubOptions.headers.authorization = `token ${gitHubToken}`;
+    }
 
     const externalOptions = {
       GOOGLE_DOCS2MD_CLIENT_ID,

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ const { errorResponse, base64 } = require('./utils.js');
 const github = require('./github');
 const google = require('./google');
 const onedrive = require('./onedrive');
+const { getCredentials } = require('./credentials.js');
 
 const DEFAULT_FORWARD_HEADERS = [
   'x-request-id',
@@ -120,6 +121,7 @@ async function main(req, context) {
       || req.headers.get('x-openwhisk-activation-id')
       || '',
       namespace,
+      gitHubToken,
     };
 
     const dataOptions = {
@@ -187,6 +189,11 @@ async function main(req, context) {
       return errorResponse(log, 501,
         `No handler found for type ${mp.type} at path ${path} (${owner}/${repo})`,
         'Invalid mount configuration');
+    }
+
+    // extract credentials
+    if (gitHubToken && mp) {
+      externalOptions.credentials = getCredentials(log, mp, gitHubToken);
     }
 
     if (path.match(/sitemap(-[^/]+)?\.xml$/) && handler.handleSitemapXML) {

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ async function main(req, context) {
         return headers;
       }, {
         // pass on authorization token
-        Authorization: gitHubToken ? `token ${gitHubToken}` : undefined,
+        authorization: gitHubToken ? `token ${gitHubToken}` : undefined,
       }),
     };
 

--- a/src/lookup-edit-url.js
+++ b/src/lookup-edit-url.js
@@ -22,6 +22,11 @@ const HANDLERS = [
   github,
 ];
 
+/**
+ * Performs a lookup from the edit url to the source document.
+ * @param {EditLookupOptions} opts options
+ * @returns {Promise<Response>} a http response
+ */
 async function lookupEditUrl(opts) {
   const {
     mount,

--- a/src/lookup-edit-url.js
+++ b/src/lookup-edit-url.js
@@ -13,6 +13,7 @@ const { Response } = require('@adobe/helix-universal');
 const google = require('./google-edit-link.js');
 const onedrive = require('./onedrive-edit-link.js');
 const github = require('./github-edit-link.js');
+const { getCredentials } = require('./credentials.js');
 const { errorResponse } = require('./utils.js');
 
 const HANDLERS = [
@@ -27,6 +28,7 @@ async function lookupEditUrl(opts) {
     uri,
     log,
     path,
+    options,
   } = opts;
 
   // extract resource path w/o extension.
@@ -45,6 +47,11 @@ async function lookupEditUrl(opts) {
   const handler = HANDLERS.find(({ test }) => test && test(mp));
   if (!handler) {
     return errorResponse(log, 404, `No handler found for document ${uri}.`, 'Not Found');
+  }
+
+  // extract credentials
+  if (options.gitHubToken) {
+    options.credentials = getCredentials(log, mp, options.gitHubToken);
   }
 
   let location;

--- a/src/onedrive-edit-link.js
+++ b/src/onedrive-edit-link.js
@@ -10,36 +10,20 @@
  * governing permissions and limitations under the License.
  */
 
-const { OneDrive } = require('@adobe/helix-onedrive-support');
+const { getOneDriveClient } = require('./onedrive-helpers.js');
 
 function test(mp) {
   return mp && mp.type === 'onedrive';
 }
 
+/**
+ * Performs a lookup from the edit url to the source document.
+ * @param {EditLookupOptions} opts options
+ * @returns {Promise<string>} the resolved url
+ */
 async function getEditUrl(opts) {
-  const {
-    mp, log, options,
-  } = opts;
-
-  if (options.credentials) {
-    // todo: respect credentials
-  }
-
-  const {
-    AZURE_WORD2MD_CLIENT_ID: clientId,
-    AZURE_WORD2MD_CLIENT_SECRET: clientSecret,
-    AZURE_HELIX_USER: username,
-    AZURE_HELIX_PASSWORD: password,
-  } = options;
-
-  const drive = new OneDrive({
-    clientId,
-    clientSecret,
-    username,
-    password,
-    log,
-  });
-
+  const { mp, log } = opts;
+  const drive = await getOneDriveClient(opts);
   log.debug(`resolving sharelink to ${mp.url}`);
   const rootItem = await drive.getDriveItemFromShareLink(mp.url);
   log.debug(`retrieving item for ${mp.relPath}`);

--- a/src/onedrive-edit-link.js
+++ b/src/onedrive-edit-link.js
@@ -21,6 +21,10 @@ async function getEditUrl(opts) {
     mp, log, options,
   } = opts;
 
+  if (options.credentials) {
+    // todo: respect credentials
+  }
+
   const {
     AZURE_WORD2MD_CLIENT_ID: clientId,
     AZURE_WORD2MD_CLIENT_SECRET: clientSecret,

--- a/src/onedrive-helpers.js
+++ b/src/onedrive-helpers.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const { OneDrive } = require('@adobe/helix-onedrive-support');
+
+async function getOneDriveClient(opts) {
+  const {
+    log, options,
+  } = opts;
+
+  const clientOpts = {
+    log,
+    clientId: options.AZURE_WORD2MD_CLIENT_ID,
+    clientSecret: options.AZURE_WORD2MD_CLIENT_SECRET,
+  };
+
+  if (options.credentials) {
+    if (options.credentials.r) {
+      log.info('using mountpoint specific refresh token');
+      clientOpts.refreshToken = options.credentials.r;
+    } else if (options.credentials.u && options.credentials.p) {
+      log.info('using mountpoint specific username / password');
+      clientOpts.username = options.credentials.u;
+      clientOpts.password = options.credentials.p;
+    } else {
+      log.info('unknown credentials specified for mountpoint');
+    }
+  }
+
+  if (!clientOpts.username || !clientOpts.refreshToken) {
+    clientOpts.username = options.AZURE_HELIX_USER;
+    clientOpts.password = options.AZURE_HELIX_PASSWORD;
+  }
+
+  return new OneDrive(clientOpts);
+}
+
+async function getAccessToken(opts) {
+  const drive = await getOneDriveClient(opts);
+  return drive.getAccessToken();
+}
+
+module.exports = {
+  getOneDriveClient,
+  getAccessToken,
+};

--- a/src/onedrive-json.js
+++ b/src/onedrive-json.js
@@ -23,6 +23,10 @@ async function handleJSON(opts, params) {
     mp, log, options, resolver,
   } = opts;
 
+  if (options.credentials) {
+    // todo: respect credentials
+  }
+
   const {
     AZURE_WORD2MD_CLIENT_ID: clientId,
     AZURE_WORD2MD_CLIENT_SECRET: clientSecret,

--- a/src/onedrive-reverse.js
+++ b/src/onedrive-reverse.js
@@ -37,7 +37,7 @@ function test(uri) {
  * - https://{tennat}/:w:/r/{site}/{subsite}/_layouts/15/guestaccess.aspx?e=4%3AxSM7pa&at=9&wdLOR=c64EF58AE-CEBB-0540-B444-044062648A17&share=ERMQVuCr7S5FqIBgvCJezO0BUUxpzherbeKSSPYCinf84w
  *
  * Documents on share links with or w/o email:
- * - https://{tennat}/:w:/s/{site}/EfaZv8TXBKtNkDb8MH0HoOsBnwRunv3BxXZ_-XgcEwiqew?email={email}&e=RLSD8R
+ * - https://{tenant}/:w:/s/{site}/EfaZv8TXBKtNkDb8MH0HoOsBnwRunv3BxXZ_-XgcEwiqew?email={email}&e=RLSD8R
  * - https://{tenant}/:w:/s/{site}/EfaZv8TXBKtNkDb8MH0HoOsBnwRunv3BxXZ_-XgcEwiqew?e=YxP8QV
  *
  * @param {ReverseLookupOptions} opts options

--- a/src/onedrive-reverse.js
+++ b/src/onedrive-reverse.js
@@ -65,6 +65,10 @@ async function reverseLookup(opts) {
     log,
   });
 
+  if (options.githubToken) {
+    // todo: respect credentials
+  }
+
   // if uri is sharelink, resolve it first
   if (uri.searchParams.get('share') || uri.pathname.indexOf('/s/') >= 0) {
     try {

--- a/src/onedrive-sitemap.js
+++ b/src/onedrive-sitemap.js
@@ -14,32 +14,18 @@ const { OneDrive } = require('@adobe/helix-onedrive-support');
 const { utils } = require('@adobe/helix-shared');
 const { Response } = require('@adobe/helix-universal');
 const { errorResponse } = require('./utils');
+const { getOneDriveClient } = require('./onedrive-helpers.js');
 
+/**
+ * Fetches an excel sheet with sitemap data from the external source.
+ * @param {ExternalHandlerOptions} opts the options.
+ * @returns {Promise<Response>} a http response
+ */
 async function handleSitemapXML(opts) {
-  const {
-    mp, log, options,
-  } = opts;
-
-  if (options.credentials) {
-    // todo: respect credentials
-  }
-
-  const {
-    AZURE_WORD2MD_CLIENT_ID: clientId,
-    AZURE_WORD2MD_CLIENT_SECRET: clientSecret,
-    AZURE_HELIX_USER: username,
-    AZURE_HELIX_PASSWORD: password,
-  } = options;
+  const { mp, log } = opts;
 
   try {
-    const drive = new OneDrive({
-      clientId,
-      clientSecret,
-      username,
-      password,
-      log,
-    });
-
+    const drive = await getOneDriveClient(opts);
     log.debug(`resolving sharelink to ${mp.url}`);
     const rootItem = await drive.getDriveItemFromShareLink(mp.url);
     log.debug(`retrieving item-id for ${mp.relPath}.xml`);

--- a/src/onedrive-sitemap.js
+++ b/src/onedrive-sitemap.js
@@ -20,6 +20,10 @@ async function handleSitemapXML(opts) {
     mp, log, options,
   } = opts;
 
+  if (options.credentials) {
+    // todo: respect credentials
+  }
+
   const {
     AZURE_WORD2MD_CLIENT_ID: clientId,
     AZURE_WORD2MD_CLIENT_SECRET: clientSecret,

--- a/src/onedrive.js
+++ b/src/onedrive.js
@@ -14,6 +14,7 @@ const { utils } = require('@adobe/helix-shared');
 const { handleJSON } = require('./onedrive-json.js');
 const { handleSitemapXML } = require('./onedrive-sitemap.js');
 const { fetch, getFetchOptions, errorResponse } = require('./utils');
+const { getAccessToken } = require('./onedrive-helpers.js');
 
 /**
  * Retrieves a file from OneDrive
@@ -41,7 +42,14 @@ async function handle(opts) {
   url.searchParams.append('rid', options.requestId);
   url.searchParams.append('src', `${owner}/${repo}/${ref}`);
 
-  const response = await fetch(url.href, getFetchOptions(options));
+  const fetchOptions = getFetchOptions(options);
+
+  const { accessToken } = await getAccessToken(opts);
+  if (accessToken) {
+    fetchOptions.headers.authorization = `Bearer ${accessToken}`;
+  }
+
+  const response = await fetch(url.href, fetchOptions);
   const body = await response.text();
   if (response.ok) {
     const headers = {

--- a/src/onedrive.js
+++ b/src/onedrive.js
@@ -18,14 +18,8 @@ const { getAccessToken } = require('./onedrive-helpers.js');
 
 /**
  * Retrieves a file from OneDrive
- * @param {object} opts options
- * @param {object} opts.mp the mountpoint as defined by helix-shared
- * @param {string} opts.owner the GitHub org or username
- * @param {string} opts.repo the GitHub repository
- * @param {string} opts.ref the GitHub ref
- * @param {object} opts.log a Helix-Log instance
- * @param {object} opts.options Helix Fetch options
- * @param {Resolver} opts.resolver Version lock helper
+ * @param {ExternalHandlerOptions} opts the options
+ * @return {Promise<Response>} the http response
  */
 async function handle(opts) {
   const {
@@ -44,11 +38,10 @@ async function handle(opts) {
 
   const fetchOptions = getFetchOptions(options);
 
-  const { accessToken } = await getAccessToken(opts);
+  const accessToken = await getAccessToken(opts);
   if (accessToken) {
     fetchOptions.headers.authorization = `Bearer ${accessToken}`;
   }
-
   const response = await fetch(url.href, fetchOptions);
   const body = await response.text();
   if (response.ok) {

--- a/src/reverse.js
+++ b/src/reverse.js
@@ -21,6 +21,11 @@ const HANDLERS = [
   // github,
 ];
 
+/**
+ * Performs a reverse lookup from an edit url to a website url.
+ * @param {ReverseLookupOptions} opts the options.
+ * @returns {Promise<Response>} a http response
+ */
 async function reverseLookup(opts) {
   const {
     uri,
@@ -43,12 +48,7 @@ async function reverseLookup(opts) {
 
   let { prefix } = opts;
   if (!prefix) {
-    prefix = `${repo}--${owner}.hlx.page`;
-    if (ref && ref !== 'master' && ref !== 'main') {
-      prefix = `https://${ref}--${prefix}`;
-    } else {
-      prefix = `https://${prefix}`;
-    }
+    prefix = `https://${ref}--${repo}--${owner}.hlx.page`;
   }
 
   // make author friendly

--- a/src/utils.js
+++ b/src/utils.js
@@ -93,6 +93,14 @@ function errorResponse(log, status, message, body = '', cacheCtl = '') {
   });
 }
 
+/**
+ * Performs a url-safe base64 encoding
+ *
+ * todo: replace with `Buffer.toString('base64url')` for node 15.
+ *
+ * @param {string} str the input stream
+ * @returns {string} the encoded string.
+ */
 function base64(str) {
   return Buffer.from(str, 'utf-8').toString('base64')
     .replace(/\+/, '-')

--- a/test/credentials.test.js
+++ b/test/credentials.test.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+const assert = require('assert');
+const { MountConfig } = require('@adobe/helix-shared');
+const { getCredentials, encrypt } = require('../src/credentials.js');
+
+const TEST_KEY = 'hello-key';
+
+describe('Credentials Tests', () => {
+  it('returns null for mountpoint w/o credentials', async () => {
+    const fstab = await new MountConfig()
+      .withSource(`
+      mountpoints:
+        /: https://my.sharepoint.com/foo
+      `).init();
+    const mp = fstab.match('/foo');
+    assert.deepEqual(getCredentials(console, mp, TEST_KEY), null);
+  });
+
+  it('returns null for mountpoint with invalid credentials', async () => {
+    const fstab = await new MountConfig()
+      .withSource(`
+      mountpoints:
+        /: 
+          url: https://my.sharepoint.com/foo
+          credentials: 
+            - foobar
+            -
+            - asbar
+      `).init();
+    const mp = fstab.match('/foo');
+    assert.deepEqual(getCredentials(console, mp, TEST_KEY), null);
+  });
+
+  it('returns correct credentials', async () => {
+    const creds = encrypt(TEST_KEY, JSON.stringify({ user: 'foo', pass: 'bar' }));
+    const fstab = await new MountConfig()
+      .withSource(`
+      mountpoints:
+        /: 
+          url: https://my.sharepoint.com/foo
+          credentials: ${creds}
+      `).init();
+    const mp = fstab.match('/foo');
+    assert.deepEqual(getCredentials(console, mp, TEST_KEY), {
+      user: 'foo',
+      pass: 'bar',
+    });
+  });
+
+  it('ignores outdated credentials', async () => {
+    const creds1 = encrypt('old-key', JSON.stringify({ user: 'zoo', pass: 'panda' }));
+    const creds2 = encrypt(TEST_KEY, JSON.stringify({ user: 'foo', pass: 'bar' }));
+    const fstab = await new MountConfig()
+      .withSource(`
+      mountpoints:
+        /: 
+          url: https://my.sharepoint.com/foo
+          credentials: 
+            - ${creds1}
+            - ${creds2}
+      `).init();
+    const mp = fstab.match('/foo');
+    assert.deepEqual(getCredentials(console, mp, TEST_KEY), {
+      user: 'foo',
+      pass: 'bar',
+    });
+  });
+
+  it('returns null for non json string credentials', async () => {
+    const creds = encrypt(TEST_KEY, 'this is not json!');
+    const fstab = await new MountConfig()
+      .withSource(`
+      mountpoints:
+        /: 
+          url: https://my.sharepoint.com/foo
+          credentials: ${creds}
+      `).init();
+    const mp = fstab.match('/foo');
+    assert.deepEqual(getCredentials(console, mp, TEST_KEY), null);
+  });
+});

--- a/test/dev/creds.js
+++ b/test/dev/creds.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const { encrypt } = require('../../src/credentials.js');
+
+const KEY = 'ghp_test_key';
+const creds = JSON.stringify({
+  user: 'test@example.com',
+  pass: 'foobar',
+});
+
+// eslint-disable-next-line no-console
+console.log(`\n  credentials: ${encrypt(KEY, creds)}`);

--- a/test/dev/creds.js
+++ b/test/dev/creds.js
@@ -12,10 +12,11 @@
 
 const { encrypt } = require('../../src/credentials.js');
 
-const KEY = 'ghp_test_key';
+const KEY = 'ghp_xxxx';
 const creds = JSON.stringify({
-  user: 'test@example.com',
-  pass: 'foobar',
+  // u: 'test@example.com',
+  // p: 'foobar',
+  r: '.....-xxxxx',
 });
 
 // eslint-disable-next-line no-console

--- a/test/dev/index.js
+++ b/test/dev/index.js
@@ -11,24 +11,45 @@
  */
 /* eslint-disable no-console */
 
+const path = require('path').posix;
 const { Request } = require('@adobe/helix-universal');
 const { main } = require('../../src/index.js');
 
 require('dotenv').config();
 
+const resolver = {
+  createURL(opts) {
+    const {
+      name,
+      package: packageName = '',
+      version = '',
+    } = opts;
+    const api = process.env.HLX_AWS_API;
+    const region = process.env.HLX_AWS_REGION;
+    return new URL(path.join(`https://${api}.execute-api.${region}.amazonaws.com`, packageName, name, version));
+  },
+};
+
 async function run() {
   const url = new URL('https://adobeioruntime.net/api/v1/web/helix/helix-services/content-proxy@v2');
-  url.searchParams.append('owner', 'adobe');
-  url.searchParams.append('repo', 'spark-website');
+  url.searchParams.append('owner', 'tripodsan');
+  url.searchParams.append('repo', 'private-pages-test');
   url.searchParams.append('ref', 'main');
-  url.searchParams.append('path', '/');
-  url.searchParams.append('lookup', 'https://adobe.sharepoint.com/:w:/r/sites/SparkHelix/_layouts/15/guestaccess.aspx?e=4%3AxSM7pa&at=9&wdLOR=c64EF58AE-CEBB-0540-B444-044062648A17&share=ERMQVuCr7S5FqIBgvCJezO0BUUxpzherbeKSSPYCinf84w');
+  url.searchParams.append('path', '/private/index.html');
+  // url.searchParams.append('lookup', 'https://adobe.sharepoint.com/:w:/r/sites/SparkHelix/_layouts/15/guestaccess.aspx?e=4%3AxSM7pa&at=9&wdLOR=c64EF58AE-CEBB-0540-B444-044062648A17&share=ERMQVuCr7S5FqIBgvCJezO0BUUxpzherbeKSSPYCinf84w');
   // const url = new URL('https://adobeioruntime.net/api/v1/web/helix/helix-services/content-proxy@v2?owner=adobe&repo=theblog&ref=master&path=%2F&lookup=https%3A%2F%2Fadobe.sharepoint.com%2Fsites%2FTheBlog%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257BBFD9A19C-4A68-4DBF-8641-DA2F1283C895%257D%26file%3Dindex.docx%26action%3Ddefault%26mobileredirect%3Dtrue%26cid%3Db6e62d68-f53a-471f-a686-90e69458fdd7');
   // const url = new URL('https://adobeioruntime.net/api/v1/web/helix/helix-services/content-proxy@v2?owner=adobe&repo=theblog&ref=master&path=%2F&lookup=https%3A%2F%2Fadobe.sharepoint.com%2F%3Aw%3A%2Fr%2Fsites%2FTheBlog%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257BBFD9A19C-4A68-4DBF-8641-DA2F1283C895%257D%26file%3Dindex.docx%26action%3Ddefault%26mobileredirect%3Dtrue%26cid%3Db6e62d68-f53a-471f-a686-90e69458fdd7');
-  const result = await main(new Request(url), {
+  const result = await main(new Request(url, {
+    headers: {
+      'x-github-token': 'ghp_xxxx',
+    },
+  }), {
+    resolver,
     log: console,
     env: process.env,
   });
+  console.log(result.status);
+  console.log(result.headers.plain());
   console.log(await result.text());
 }
 

--- a/test/dev/index.js
+++ b/test/dev/index.js
@@ -14,6 +14,7 @@
 const path = require('path').posix;
 const { Request } = require('@adobe/helix-universal');
 const { main } = require('../../src/index.js');
+const { base64 } = require('../../src/utils.js');
 
 require('dotenv').config();
 
@@ -32,10 +33,13 @@ const resolver = {
 
 async function run() {
   const url = new URL('https://adobeioruntime.net/api/v1/web/helix/helix-services/content-proxy@v2');
+  const urlPath = `/hlx_${base64('https://adobe.sharepoint.com/:w:/r/sites/SparkHelix/_layouts/15/guestaccess.aspx?e=4%3AxSM7pa&at=9&wdLOR=c64EF58AE-CEBB-0540-B444-044062648A17&share=ERMQVuCr7S5FqIBgvCJezO0BUUxpzherbeKSSPYCinf84w')}.lnk`;
+  console.log(urlPath);
   url.searchParams.append('owner', 'tripodsan');
   url.searchParams.append('repo', 'private-pages-test');
   url.searchParams.append('ref', 'main');
-  url.searchParams.append('path', '/private/index.html');
+  // url.searchParams.append('path', '/private/index.html');
+  url.searchParams.append('path', urlPath);
   // url.searchParams.append('lookup', 'https://adobe.sharepoint.com/:w:/r/sites/SparkHelix/_layouts/15/guestaccess.aspx?e=4%3AxSM7pa&at=9&wdLOR=c64EF58AE-CEBB-0540-B444-044062648A17&share=ERMQVuCr7S5FqIBgvCJezO0BUUxpzherbeKSSPYCinf84w');
   // const url = new URL('https://adobeioruntime.net/api/v1/web/helix/helix-services/content-proxy@v2?owner=adobe&repo=theblog&ref=master&path=%2F&lookup=https%3A%2F%2Fadobe.sharepoint.com%2Fsites%2FTheBlog%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257BBFD9A19C-4A68-4DBF-8641-DA2F1283C895%257D%26file%3Dindex.docx%26action%3Ddefault%26mobileredirect%3Dtrue%26cid%3Db6e62d68-f53a-471f-a686-90e69458fdd7');
   // const url = new URL('https://adobeioruntime.net/api/v1/web/helix/helix-services/content-proxy@v2?owner=adobe&repo=theblog&ref=master&path=%2F&lookup=https%3A%2F%2Fadobe.sharepoint.com%2F%3Aw%3A%2Fr%2Fsites%2FTheBlog%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257BBFD9A19C-4A68-4DBF-8641-DA2F1283C895%257D%26file%3Dindex.docx%26action%3Ddefault%26mobileredirect%3Dtrue%26cid%3Db6e62d68-f53a-471f-a686-90e69458fdd7');

--- a/test/fixtures/OneDrive-Integration-Tests_690026202/Retrieves-Document-from-Word_3165599571/recording.har
+++ b/test/fixtures/OneDrive-Integration-Tests_690026202/Retrieves-Document-from-Word_3165599571/recording.har
@@ -4,11 +4,11 @@
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
-      "version": "4.2.1"
+      "version": "5.1.0"
     },
     "entries": [
       {
-        "_id": "a50ce63a9d33dacaea234bcd59d1efdc",
+        "_id": "43d352739c2a39c834d2014885dda5e8",
         "_order": 0,
         "cache": {},
         "request": {
@@ -16,27 +16,23 @@
           "cookies": [],
           "headers": [
             {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "accept",
-              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+              "name": "host",
+              "value": "adobeioruntime.net"
             },
             {
               "name": "user-agent",
               "value": "helix-fetch"
             },
             {
-              "name": "accept-encoding",
-              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+              "name": "accept",
+              "value": "*/*"
             },
             {
-              "name": "host",
-              "value": "adobeioruntime.net"
+              "name": "accept-encoding",
+              "value": "gzip,deflate,br"
             }
           ],
-          "headersSize": 445,
+          "headersSize": 367,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -60,103 +56,111 @@
           "url": "https://adobeioruntime.net/api/v1/web/helix/helix-services/word2md@v2?path=%2Findex.docx&shareLink=https%3A%2F%2Fadobe.sharepoint.com%2Fsites%2FTheBlog%2FShared%2520Documents%2Ftheblog&rid=&src=adobe%2Ftheblog%2Fcb8a0dc5d9d89b800835166783e4130451d3c6a5"
         },
         "response": {
-          "bodySize": 1108,
+          "bodySize": 729,
           "content": {
             "mimeType": "text/plain; charset=UTF-8",
-            "size": 1108,
-            "text": "# The Blog | Welcome to Adobe Blog\n\n---\n\n## Featured Posts\n\n-   <https://blog.adobe.com/en/2020/09/14/inside-adobes-employee-focused-covid-19-response-roadmap.html>\n-   [https://blog.adobe.com/en/2020/06/10/listening-learning-and-taking-action.html](https://blog.adobe.com/en/2020/06/10/listening-learning-and-taking-action.html#gs.d75w28)\n-   [https://blog.adobe.com/en/2020/08/17/max-2020-registration-is-officially-open.html](https://blog.adobe.com/en/2020/08/17/max-2020-registration-is-officially-open.html#gs.dsb9w8)\n-   <https://blog.adobe.com/en/2020/08/13/smb-playbook-for-customer-experience-management.html>\n\n---\n\n## News\n\n### Our response to COVID-19\n\nCheck out our collection of stories to help you stay creative, be resilient, and get inspired.\n\n[More on COVID-19](https://blog.adobe.com/en/topics/covid-19.html)\n\n-   <https://blog.adobe.com/en/2020/09/03/adobe-events-go-virtual-through-june-2021.html#gs.fkkxus>\n-   <https://blog.adobe.com/en/2020/09/10/post-covid-cio-priorities-apac.html>\n-   <https://blog.adobe.com/en/2020/09/10/petbarn-makes-online-shopping-easy-for-pets-pandemic.html>\n"
+            "size": 729,
+            "text": "# The Blog | Welcome to Adobe Blog\n\n---\n\n## Featured Posts\n\n-   <https://blog.adobe.com/en/publish/2021/04/12/lessons-learned-21-years-on-fortune-100-best-companies.html>\n\n---\n\n## News\n\n### Road to Adobe Summit\n\nThe Digital Experience Conference – April 27-29, 2021\n\n[Browse the collection](https://blog.adobe.com/en/topics/adobe-summit.html)\n\n-   <https://blog.adobe.com/en/publish/2021/02/01/registration-is-open-adobe-summit-2021-is-free-virtual-and-global.html>\n-   <https://blog.adobe.com/en/publish/2021/03/22/world-class-experience-makers-headline-adobe-summit-keynotes.html>\n-   <https://blog.adobe.com/en/publish/2021/04/09/getting-real-about-personalization-at-scale.html>\n\n---\n\nExclude: UK Exclusive, APAC Exclusive\n"
           },
           "cookies": [],
           "headers": [
             {
-              "name": "access-control-allow-headers",
-              "value": "Authorization, Origin, X-Requested-With, Content-Type, Accept, User-Agent"
-            },
-            {
-              "name": "access-control-allow-methods",
-              "value": "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": "*"
-            },
-            {
               "name": "cache-control",
               "value": "no-store, private, must-revalidate"
+            },
+            {
+              "name": "content-length",
+              "value": "729"
             },
             {
               "name": "content-type",
               "value": "text/plain; charset=UTF-8"
             },
             {
-              "name": "date",
-              "value": "Thu, 17 Sep 2020 10:13:52 GMT"
-            },
-            {
               "name": "last-modified",
-              "value": "Thu, 17 Sep 2020 09:13:52 GMT"
-            },
-            {
-              "name": "perf-br-resp-out",
-              "value": "1600337632.894"
-            },
-            {
-              "name": "server-timing",
-              "value": "p00;dur=0.79;desc=lookup ,p01;dur=980.17;desc=resolve ,p02;dur=1210.89;desc=download ,p03;dur=88.29;desc=parseDocx ,p04;dur=0.18;desc=toMdast ,p05;dur=0.55;desc=postProcess ,p06;dur=1.17;desc=toString ,p07;dur=0.00;desc=convert, total;dur=2282.043214"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=7884000; includeSubDomains"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "deny"
-            },
-            {
-              "name": "x-gw-cache",
-              "value": "MISS"
-            },
-            {
-              "name": "x-last-activation-id",
-              "value": "5a3aad3f75d840b1baad3f75d8e0b1f1"
-            },
-            {
-              "name": "x-openwhisk-activation-id",
-              "value": "c9c3129ec415465383129ec41526532d"
+              "value": "Mon, 12 Apr 2021 18:31:29 GMT"
             },
             {
               "name": "x-request-id",
-              "value": "qrv1SBQJWdgbeMggb96evkuhFqoZUjxv"
+              "value": "cpeEf8qxxf9dO3qmI3ykaJdlHqmV61Hp"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "Authorization, Origin, X-Requested-With, Content-Type, Accept, User-Agent"
+            },
+            {
+              "name": "x-openwhisk-activation-id",
+              "value": "c2b9114bc4bf4f47b9114bc4bf0f473f"
+            },
+            {
+              "name": "server-timing",
+              "value": "p00;dur=0.05;desc=lookup ,p01;dur=1061.62;desc=resolve ,p02;dur=2227.52;desc=download ,p03;dur=60.29;desc=parseDocx ,p04;dur=0.22;desc=toMdast ,p05;dur=0.89;desc=postProcess ,p06;dur=0.72;desc=toString ,p07;dur=0.00;desc=convert,total;dur=3351.325905"
+            },
+            {
+              "name": "x-last-activation-id",
+              "value": "34833301be7f4add833301be7faadd31"
             },
             {
               "name": "x-source-location",
               "value": "/drives/b!PpnkewKFAEaDTS6slvlVjh_3ih9lhEZMgYWwps6bPIWZMmLU5xGqS4uES8kIQZbH/items/01DJQLOW44UHM362CKX5GYMQO2F4JIHSEV"
             },
             {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "content-length",
-              "value": "1108"
+              "name": "perf-br-resp-out",
+              "value": "1618465777.651"
+            },
+            {
+              "name": "x-gw-cache",
+              "value": "MISS"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=7884000; includeSubDomains"
+            },
+            {
+              "name": "x-envoy-upstream-service-time",
+              "value": "3379"
+            },
+            {
+              "name": "x-azure-ref",
+              "value": "07tN3YAAAAAAnM4NMleqIRrqxKi5fE3S2VFlPMDFFREdFMDQxNQBiNzdiNjYzMy04ZjcwLTQyNWItOTJiZC03NmFlYmU5YWI5YzU="
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Apr 2021 05:49:37 GMT"
             },
             {
               "name": "connection",
-              "value": "keep-alive"
+              "value": "close"
             }
           ],
-          "headersSize": 1162,
+          "headersSize": 1355,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-09-17T10:13:49.926Z",
-        "time": 3129,
+        "startedDateTime": "2021-04-15T05:49:34.225Z",
+        "time": 3464,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +168,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 3129
+          "wait": 3464
         }
       }
     ],

--- a/test/fixtures/OneDrive-Integration-Tests_690026202/Retrieves-Document-from-a-private-repository-with-credentials_809520207/recording.har
+++ b/test/fixtures/OneDrive-Integration-Tests_690026202/Retrieves-Document-from-a-private-repository-with-credentials_809520207/recording.har
@@ -1,0 +1,361 @@
+{
+  "log": {
+    "_recordingName": "OneDrive Integration Tests/Retrieves Document from a private repository with credentials",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "5.1.0"
+    },
+    "entries": [
+      {
+        "_id": "6c569acd22c5a88c4a1f0bd619afec8a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1411,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "8e9c94a5-9f47-4705-a159-a79df84fd9df"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.2.1-patch.0"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.windows.net"
+            },
+            {
+              "name": "content-length",
+              "value": 1411
+            }
+          ],
+          "headersSize": 376,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.windows.net/common/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 4762,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 4762,
+            "text": "{\"token_type\":\"Bearer\",\"scope\":\"Files.ReadWrite.All MyFiles.Read Sites.ReadWrite.All User.Read\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1618469638\",\"not_before\":\"1618465738\",\"resource\":\"https://graph.microsoft.com\",\"access_token\":\"aaA0aAAaAaAAA0AaAAAaa00aAAA0AaA0aAAAAaaAAAAAA00aA0AAAAAaaaaAAAAaA0A0AAA0AAaAa0aaAaAAAA0aAAAaaAaaAaAAAaA0AaAaAaa0aAA0Aa0AaaAaAAAAAAaAAaAaA0aaAAAaAAAaA0aAAaAaAaaaAAA0Aa0AaaAaAAAAAAaAAaAaA0aaAAAaAAAaA0aAAaA0.aaAaaAAaAaAaaAAaaaaaA0aaAAAaAa0aA0Aaa00aaA0aa00aAAAaa0AaAaAaaAAaaaaaA0A0aa00aA0aa0aaAa0aaA0aAAaaAAA0AA00AaA0AAAaAAaaAAAaAA0aAaAaAaaaAAAaAAAaAaaaaAA0AaaaAaA0AAA0AaA0AAAaAaAaAaA0AAa0AaA0AaaaAaA0aAA0AAAaAAA0AAAaAAaaAAAaaAA0AAaaAAAaAaaaAAAaAaAaaaAaAaaaaAAaAaAaAAA0aaAaaAA0AAAaAAA0aaa0aAaaAa0aAAA0aa00aAaaaa0aa0A0AaAaaAAaAAA0aa00aAaaaa0aa0A0AaAaaAAaAAA0aa00aAaaaa0aa0A0AaAaaAAaAAAaAAAaAaAaAaaaAaAaAAAaAAAaAaA0AaaaAaAaAAAaAaAaAaA0AaaaAaaaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAaaAAAaAAaaAAAaAAaaAAAaAaAaAAAaAaAaAAAaAaAaAAAaAaAaAAAaAaAaAAAaAaAaAAaaAAaaAaaaAAAAAAAaAAAAAAAAA0AAAAAAA0a0aAAAaaa0A00AAAaAAAAAAaAaaAA0AA0AAa0AAAAaaAAaAAAAaaAaAAAaA0aAAAaaAaAAAAAaAaaAAAaaaaAAAAAaAAAaaAaAa0AAAAA0AAAaAaAaaaA0AaAaa0AaAAAaAaAaAAaaAAAaA0Aaa0AaAAaaAA0aAaaaAAAaaAaaAA0aAa0aaaaaa0aaAAAaaaAaA0AaAAAaaAAaAAA0AaaaAAAaAAAaAAAaAAAaAAA0AA00AaAaAAAaAAAaAaA0Aaa0AaAaAaAaaAaaAAAaAaaaAAAaAaAaaAaaaA0aAA0aAaaaAAAaaAaaAAAaaaA0AAAaAaaaaaAaA00aaAAaAaAAaa0aAAA0AaaaaAA0aAAaAaA0a0AaAaaaaAAaAAAaAaaaAAAaAaAaAaA0AA00AAAaAa0aaAAaAaAAaa0aAAA0AAaaaAa0AAAaaAAaaAAaAAAaaAAaAaAaAAAaAAA0AA00A0AaAAA0AAAaAAA0Aa0aAAA0AAA0AAAaAAAaAAAaaaAaAA0aa0aaAaaaAa0aAAAaAaAaAaAaAAa0AaA0AAAaAaA0AaAaAAaaAAA0AaAaAAAaAAaaAaA0AAAaAaAaAAAaAaaaAAAaAAAaaAaaAaaaAAAaAaAaAAAaAAA0AAAAAAAaAaAaAaaaAA0AA0aAA0a0Aa0aAaaaAA0AaaAAAaAAA000A0aaaAAAAaaaAA0aaaAAAAA0AaaAAA0AAAAaAaaaa0AaAaaaAaaaAAAaAaAaAAaaaAAaAaAaaAAAaAAaaAAaAaAaAAAaA0a0AAAaAaAaAAaaaAAaAaAaaAAAa0AaAaAaAAAaAAAaaAAaAaAAAAA0aAa0AaAaAA0Aa0aaA0aaaaAaAAAaAaa0AA0aAAA0AAA0AaaaaaAAAaaaaAAaAA00A0AaA0aaaa0aA00aAAA0AaaAAaaaaAaaAaaaAaA0AaAaAAAaA0AaAA00Aaa0AAa0AAAaAAAaAAa0AAAaAAAaAaaaaA0aaAAaA00aaAAaAaAaAAaaaAAaAAAaa0AaAaAaaAAaAaAaaaA0AaaaaAa0A0AAAAAaAaAaA00aAaaaaAAaAaaaaAAAaAaAA0AAAAaaA0aAAaaaaa0AAAAaAaAaaaA0AaAaAAAaAaaaAAAaAaaaAaa0AaAaAAAaA0AaAA00Aaa0AAaaAAAaAaAaAAa0AAa0AAA0Aa0aAaaaa000A0A0AaaaAaAaAAAaAaA0aA.aaAaAaA0a0aAAAa_0A00A-AaaA0aAAaA0AAaA0AaaaA0AaAaaaAAAaAAAaA0AaaAAAAaaaA0a0aaa0AAa0aaAAaaaAAAAA0a0-Aaa0AaaaAaAAaaAa0aa-0AaaA0AaA0aaAa0a0000aaAaaAaaAaAaaAaAAaAaAA00AaaaaAAaaa0a0A000AaaaAaAAAAAaAAAaAaaAAA00a0AaAA00aA0a00Aa0A0AAAa0AaaaAAaaAaaAaaAAaAa0aaAaAaaaaaaaAAAaAaaAAAaaaAAaAAAAaAAAAaaAAaaaAaaAaaaAAaaA0a0aAaA_AA0aAaaAaaAAaaa0a-aaaAaAAA00Aaa\",\"refresh_token\":\"0.AAAAAaa0-aA0a0AAaaAAaA0A0AAaa0AAA00AaaAA0A0AAAAaAAa.AaAAAAAAAAA--AAA0AA0AaaaaAa0AaaaAaAa_aAA0A-aAaaaAAaaAAa_0aaaAaA0AA0aaaaa0a0A0aaa_aaA_0a0AaaaAAaaAAA00aaaAaA-AAAaAAAAaAaAAa0aaaAaaAaAaaAAAa00A0aAaAAaAaAaA0Aa0AaaaAAa0-0aAAaaaAaaA-0aAAaA0AAAaaaaaaaAAaAAAaAAaAAaAaA00aAAA0AaAaAaaAA0-aA-aa0aaAAAaaaaAaaaAaa0a0AaaaaA0AAaAAaAaAAaAAAaaaAa000aa0aAAA0aAA0Aa0AaaaAA-AaAaAAA0aa00aAa-0aAA0AaAaaAaaAaAAaAaaAAAaAAaA0-aAaA0A00AaA-A_aAaaAaaaaaAAaAAaa0AAA0aaaAaAAaAAaaAAAAa0aAA0AAAaaAAAaaaAAa00aA0aa0aAAa0_AaAaA0AaA_aAAA_aAaaA00aaA0aaAAaaa0aAaA0aaAA0AaAAAaaAaa0aaaAAaaAaAAAA0aa00aAAaa0A0-aaAAAAaAa00Aaa-0AaAaa0aaaaaA-AA0aaaaaaAaAAaAaAAAAAaAaaAaAaA0aaaAa0a0aaAaaaA0AAa0aAaaAa0Aaaaa0aa0AAaaaAAAa_a0AaaaaAAa0aAAAa0aaAaAA_AAAaA0Aa0aA0Aa0aaaaaaAAA0A0AAAaa0AaaAaAAAaAaa0000aaaAaAAaAa0aAAaaaA0aaAaA0aaaaAAaAAaAAaaA00a0AaAAaa0A0aA_aAAa0aa0aaaAAAAAaAAaAaaAaA0aAA0AA0AA0aaaAAA0aAaaa0aAaAAaAA0aAAaaaA0aaa0AAA0aaAa0Aa00a00AaAAaA-Aaa0aaAaAAA000aAaaA0aa0AAAaAa0aa_0a_0AaA-AaAA-aA_AAaAaaAAAaa0AAaaaa0AAAAa0AaA-AA00AAAaA_0AA0AAAaa0a0a_A-A0AaaaaAa0AA0aAaaaA0Aaa0AA0AaAaa0AaAaAAaAAaaaaAAA_0aa0AAaaaAaaa0aaA-AaAAaAAaA00AAa_Aa-aA0aaAA0A00aaaaaaaaAAA0AaAAAA0AaAAA0a0AAaaAaAaAa0aAa0A0aAa0A00AaAAAAaAAaaAAAAaA_Aaa0aAAAAaAaA0A0aAAA_a0a0a0AaaAAaA000AAaaa-AaaAaaaAAa0a0Aa00\",\"id_token\":\"aaA0aAAaAaAAA0AaAAAaaAaaAaAaa00aAa0.aaAaaAAaAaA0A0AaAaaaAa00AaAaAAAaAAAaAAAaAa0aAAAaAaAaAAA0AAAaAAAaa0AaAaAaaAAaaaaaA0A0aa00aA0aa0aaAa0aaA0aAAaaAAA0AA00AaA0AAAaAAaaAAAaAA0aAaAaAaaaAAAaAAAaAaaaaAA0AaaaAaA0AAA0AaA0AAAaAaAaAaA0AAa0AaA0AaaaAaA0aAA0AAAaAAA0AAAaAAaaAA0aAaaaAaA0AAAaAa0aAAAaAAAaAA0aaAaaaaAaAAA0AaaaaAa0AAAaaAAaaAAaAAAaaAAaaa0aAA0aAaaaAAAaaaAaaAAaAaaaAAAaaaA0AaAaAa00Aa0aAAAaAAaaAAAaAA0aAaaaAAAaaaAaaAAAAAaaaAAAaaa0AAAaAaaaa0aaAaaaAaaaAAA0AaAaAaaaAa00AAAaAAaaAAaaAAAaA0A0AAAaAAaaAaaaa00aaaAaA0AaAAA0AaAaAA00AAAaAAa0Aaa0AAAaAA0aAAAaAAa0Aaa0AAaaAAaaAAAaAA00AaA0AaAaAAAaaAA0AaAaAAAAAAaaaAaaaaA0aAAAAAA0AAAaAaaAAAAAaAA0AAAAAAAAaAAAAaAAAAAAAaaaAAaaAaAaAaA0AaA0AaAAAAaAA0AaAa0aaA0aAAAAA0AaaaAaAAAAAAAaa0AAAAa0Aa0AAAAAA00aAAA0aAAaAaAaAAaaAAA0AA00AaA0AAAaAAaaAAAaAA0aAaAaAaaaAAAaAAAaAAA0aaaaaAAaaaAaAAA0AaaaaAa0A0AAAAAaAaAaA00aAaaaaAAaAaaaaAAaaAaaA0AaAA0aAA0aa00aAAA0AAAaAaAaAaAaaA.\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-05-15T05:53:58.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Ao_p3FhaYvFJlTwdXI19QyHMDaq-AQAAAPXLCdgOAAAA"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "estsfd"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "estsfd"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-length",
+              "value": "4762"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "8e9c94a5-9f47-4705-a159-a79df84fd9df"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "2d21a1a7-ec3f-4223-be38-a5a0f5db3e00"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11622.22 - KRSLR1 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,75232626.6488,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "fpc=Ao_p3FhaYvFJlTwdXI19QyHMDaq-AQAAAPXLCdgOAAAA; expires=Sat, 15-May-2021 05:53:58 GMT; path=/; secure; HttpOnly; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "x-ms-gateway-slice=estsfd; path=/; secure; httponly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "stsservicecookie=estsfd; path=/; secure; httponly"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Apr 2021 05:53:57 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 802,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-04-15T05:53:58.145Z",
+        "time": 184,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 184
+        }
+      },
+      {
+        "_id": "09e9d4352333a9ae279ce0384aef6bf9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "adobeioruntime.net"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip,deflate,br"
+            }
+          ],
+          "headersSize": 2720,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "path",
+              "value": "/index.docx"
+            },
+            {
+              "name": "shareLink",
+              "value": "https://adobe.sharepoint.com/sites/cg-helix/Shared%20Documents/private"
+            },
+            {
+              "name": "rid",
+              "value": ""
+            },
+            {
+              "name": "src",
+              "value": "adobe/theblog/master"
+            }
+          ],
+          "url": "https://adobeioruntime.net/api/v1/web/helix/helix-services/word2md@v2?path=%2Findex.docx&shareLink=https%3A%2F%2Fadobe.sharepoint.com%2Fsites%2Fcg-helix%2FShared%2520Documents%2Fprivate&rid=&src=adobe%2Ftheblog%2Fmaster"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "text/plain; charset=UTF-8",
+            "size": 26,
+            "text": "Hello my little secret...\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, private, must-revalidate"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "content-type",
+              "value": "text/plain; charset=UTF-8"
+            },
+            {
+              "name": "last-modified",
+              "value": "Tue, 13 Apr 2021 05:48:52 GMT"
+            },
+            {
+              "name": "x-request-id",
+              "value": "LT4EoOoYkxIfXS7oqAbZ5w8DFaI4aQup"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "Authorization, Origin, X-Requested-With, Content-Type, Accept, User-Agent"
+            },
+            {
+              "name": "x-openwhisk-activation-id",
+              "value": "11a658d263744e3ca658d263747e3c0b"
+            },
+            {
+              "name": "server-timing",
+              "value": "p00;dur=0.04;desc=lookup ,p01;dur=1091.93;desc=resolve ,p02;dur=1975.23;desc=download ,p03;dur=16.64;desc=parseDocx ,p04;dur=0.05;desc=toMdast ,p05;dur=0.13;desc=postProcess ,p06;dur=0.30;desc=toString ,p07;dur=0.00;desc=convert,total;dur=3084.31564"
+            },
+            {
+              "name": "x-last-activation-id",
+              "value": "5720fd8f70a74d0da0fd8f70a71d0dc6"
+            },
+            {
+              "name": "x-source-location",
+              "value": "/drives/b!DyVXacYnlkm_17hZL307Me9vzRzaKwZCpVMBYbPOKaVT_gD5WmlHRbC-PCpiwGPx/items/012VWERI7DM52BFAKXGVEYIR63E74CMWMN"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "perf-br-resp-out",
+              "value": "1618466041.529"
+            },
+            {
+              "name": "x-gw-cache",
+              "value": "MISS"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=7884000; includeSubDomains"
+            },
+            {
+              "name": "x-envoy-upstream-service-time",
+              "value": "3116"
+            },
+            {
+              "name": "x-azure-ref",
+              "value": "09tR3YAAAAAA31xuAuJhbSbzWCGNM+BerVFlPMDFFREdFMDQyMQBiNzdiNjYzMy04ZjcwLTQyNWItOTJiZC03NmFlYmU5YWI5YzU="
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Apr 2021 05:54:01 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 1353,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-04-15T05:53:58.374Z",
+        "time": 3200,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3200
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/fixtures/OneDrive-Integration-Tests_690026202/Retrieves-Document-from-a-private-repository-with-unknown-credentials_1980587233/recording.har
+++ b/test/fixtures/OneDrive-Integration-Tests_690026202/Retrieves-Document-from-a-private-repository-with-unknown-credentials_1980587233/recording.har
@@ -1,6 +1,6 @@
 {
   "log": {
-    "_recordingName": "OneDrive Integration Tests/Retrieves Document mounted md from Word",
+    "_recordingName": "OneDrive Integration Tests/Retrieves Document from a private repository with unknown credentials",
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "cb5947da5177c43b41ff910167bd6abf",
+        "_id": "0b6ee866aa355adfdafe7d9c8a15883b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -32,17 +32,17 @@
               "value": "gzip,deflate,br"
             }
           ],
-          "headersSize": 405,
+          "headersSize": 351,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
             {
               "name": "path",
-              "value": ""
+              "value": "/breaks.docx"
             },
             {
               "name": "shareLink",
-              "value": "onedrive:/drives/b!PpnkewKFAEaDTS6slvlVjh_3ih9lhEZMgYWwps6bPIWZMmLU5xGqS4uES8kIQZbH/items/01DJQLOW44UHM362CKX5GYMQO2F4JIHSEV"
+              "value": "https://adobe.sharepoint.com/sites/cg-helix/Shared%20Documents/word2md-unit-tests"
             },
             {
               "name": "rid",
@@ -50,17 +50,17 @@
             },
             {
               "name": "src",
-              "value": "adobe/theblog/cb8a0dc5d9d89b800835166783e4130451d3c6a5"
+              "value": "adobe/theblog/otherbranch"
             }
           ],
-          "url": "https://adobeioruntime.net/api/v1/web/helix/helix-services/word2md@v2?path=&shareLink=onedrive%3A%2Fdrives%2Fb%21PpnkewKFAEaDTS6slvlVjh_3ih9lhEZMgYWwps6bPIWZMmLU5xGqS4uES8kIQZbH%2Fitems%2F01DJQLOW44UHM362CKX5GYMQO2F4JIHSEV&rid=&src=adobe%2Ftheblog%2Fcb8a0dc5d9d89b800835166783e4130451d3c6a5"
+          "url": "https://adobeioruntime.net/api/v1/web/helix/helix-services/word2md@v2?path=%2Fbreaks.docx&shareLink=https%3A%2F%2Fadobe.sharepoint.com%2Fsites%2Fcg-helix%2FShared%2520Documents%2Fword2md-unit-tests&rid=&src=adobe%2Ftheblog%2Fotherbranch"
         },
         "response": {
-          "bodySize": 729,
+          "bodySize": 149,
           "content": {
             "mimeType": "text/plain; charset=UTF-8",
-            "size": 729,
-            "text": "# The Blog | Welcome to Adobe Blog\n\n---\n\n## Featured Posts\n\n-   <https://blog.adobe.com/en/publish/2021/04/12/lessons-learned-21-years-on-fortune-100-best-companies.html>\n\n---\n\n## News\n\n### Road to Adobe Summit\n\nThe Digital Experience Conference – April 27-29, 2021\n\n[Browse the collection](https://blog.adobe.com/en/topics/adobe-summit.html)\n\n-   <https://blog.adobe.com/en/publish/2021/02/01/registration-is-open-adobe-summit-2021-is-free-virtual-and-global.html>\n-   <https://blog.adobe.com/en/publish/2021/03/22/world-class-experience-makers-headline-adobe-summit-keynotes.html>\n-   <https://blog.adobe.com/en/publish/2021/04/09/getting-real-about-personalization-at-scale.html>\n\n---\n\nExclude: UK Exclusive, APAC Exclusive\n"
+            "size": 149,
+            "text": "# Breaks\n\n## Bold break\n\n---\n\n## Italic breaks\n\n---\n\n## Break with heading\n\n---\n\n## 3 dashes in paragraph\n\nUse 3 dashes --- to create a new section.\n"
           },
           "cookies": [],
           "headers": [
@@ -70,15 +70,19 @@
             },
             {
               "name": "content-length",
-              "value": "729"
+              "value": "149"
             },
             {
               "name": "content-type",
               "value": "text/plain; charset=UTF-8"
             },
             {
+              "name": "last-modified",
+              "value": "Sat, 27 Mar 2021 07:45:42 GMT"
+            },
+            {
               "name": "x-request-id",
-              "value": "tu4PmjuIHa0I4VWPlGgsT8r5rOr8TxtL"
+              "value": "a6w1SOTpjxQSwLcluOwSxXM9NxezqKOE"
             },
             {
               "name": "access-control-allow-origin",
@@ -94,19 +98,19 @@
             },
             {
               "name": "x-openwhisk-activation-id",
-              "value": "62d5f7d90793420395f7d90793020367"
+              "value": "efafb571b9074d08afb571b907ed0867"
             },
             {
               "name": "server-timing",
-              "value": "p00;dur=0.11;desc=lookup ,p01;dur=1.28;desc=resolve ,p02;dur=2187.21;desc=download ,p03;dur=68.40;desc=parseDocx ,p04;dur=0.37;desc=toMdast ,p05;dur=0.61;desc=postProcess ,p06;dur=1.24;desc=toString ,p07;dur=0.00;desc=convert,total;dur=2259.241729"
+              "value": "p00;dur=0.06;desc=lookup ,p01;dur=381.43;desc=resolve ,p02;dur=1290.11;desc=download ,p03;dur=20.41;desc=parseDocx ,p04;dur=0.11;desc=toMdast ,p05;dur=0.31;desc=postProcess ,p06;dur=1.02;desc=toString ,p07;dur=0.00;desc=convert,total;dur=1693.450638"
             },
             {
               "name": "x-last-activation-id",
-              "value": "dddfb6e2cf9344c89fb6e2cf9374c8b4"
+              "value": "9ab31a9576b6490eb31a9576b6490ec8"
             },
             {
               "name": "x-source-location",
-              "value": "/drives/b!PpnkewKFAEaDTS6slvlVjh_3ih9lhEZMgYWwps6bPIWZMmLU5xGqS4uES8kIQZbH/items/01DJQLOW44UHM362CKX5GYMQO2F4JIHSEV"
+              "value": "/drives/b!DyVXacYnlkm_17hZL307Me9vzRzaKwZCpVMBYbPOKaVT_gD5WmlHRbC-PCpiwGPx/items/012VWERIYIZRNKPJ74HVHKUKOV22RBEFOJ"
             },
             {
               "name": "x-frame-options",
@@ -122,7 +126,7 @@
             },
             {
               "name": "perf-br-resp-out",
-              "value": "1618465790.688"
+              "value": "1618465893.880"
             },
             {
               "name": "x-gw-cache",
@@ -134,29 +138,29 @@
             },
             {
               "name": "x-envoy-upstream-service-time",
-              "value": "2296"
+              "value": "1721"
             },
             {
               "name": "x-azure-ref",
-              "value": "0/NN3YAAAAACJqT4PWI3IQpw5pCVcJtPvVFlPMDFFREdFMDUwOABiNzdiNjYzMy04ZjcwLTQyNWItOTJiZC03NmFlYmU5YWI5YzU="
+              "value": "0ZNR3YAAAAAD2nchj7vcMQY5zpyXDSsdnVFlPMDFFREdFMDQxMQBiNzdiNjYzMy04ZjcwLTQyNWItOTJiZC03NmFlYmU5YWI5YzU="
             },
             {
               "name": "date",
-              "value": "Thu, 15 Apr 2021 05:49:50 GMT"
+              "value": "Thu, 15 Apr 2021 05:51:33 GMT"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 1306,
+          "headersSize": 1354,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-04-15T05:49:48.305Z",
-        "time": 2419,
+        "startedDateTime": "2021-04-15T05:51:32.092Z",
+        "time": 1832,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +168,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2419
+          "wait": 1832
         }
       }
     ],

--- a/test/fixtures/OneDrive-Integration-Tests_690026202/Retrieves-Document-from-a-private-repository-with-user-credentials_1569403714/recording.har
+++ b/test/fixtures/OneDrive-Integration-Tests_690026202/Retrieves-Document-from-a-private-repository-with-user-credentials_1569403714/recording.har
@@ -1,0 +1,882 @@
+{
+  "log": {
+    "_recordingName": "OneDrive Integration Tests/Retrieves Document from a private repository with user credentials",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "5.1.0"
+    },
+    "entries": [
+      {
+        "_id": "08d03434e7bab5e9aa35a7e63ae8d720",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "13e5dcce-917a-4459-b183-64d6b9be24a4"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.2.1-patch.0"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.windows.net"
+            }
+          ],
+          "headersSize": 345,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.windows.net/common/UserRealm/helix%40adobe.com?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 402,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 402,
+            "text": "{\"ver\":\"1.0\",\"account_type\":\"Federated\",\"domain_name\":\"adobe.com\",\"federation_protocol\":\"WSTrust\",\"federation_metadata_url\":\"https://adobe.okta.com/app/office365/kxg149x5TOLQDOUEMHSP/sso/wsfed/mex\",\"federation_active_auth_url\":\"https://adobe.okta.com/app/office365/kxg149x5TOLQDOUEMHSP/sso/wsfed/active\",\"cloud_instance_name\":\"microsoftonline.com\",\"cloud_audience_urn\":\"urn:federation:MicrosoftOnline\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-05-15T05:53:25.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "AqUf7AIbWS5EkKkOdlH9T-k"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "estsfd"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "estsfd"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "13e5dcce-917a-4459-b183-64d6b9be24a4"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "dba8f03b-822c-4d04-9865-754620ed0000"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11622.22 - SEASLR2 ProdSlices"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "fpc=AqUf7AIbWS5EkKkOdlH9T-k; expires=Sat, 15-May-2021 05:53:25 GMT; path=/; secure; HttpOnly; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "x-ms-gateway-slice=estsfd; path=/; secure; httponly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "stsservicecookie=estsfd; path=/; secure; httponly"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=userrealm.json"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Apr 2021 05:53:25 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "402"
+            }
+          ],
+          "headersSize": 798,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-04-15T05:53:25.710Z",
+        "time": 122,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 122
+        }
+      },
+      {
+        "_id": "ee3d9b23e010dac1abf1fb802088fd20",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/soap+xml"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "13e5dcce-917a-4459-b183-64d6b9be24a4"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.2.1-patch.0"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "adobe.okta.com"
+            }
+          ],
+          "headersSize": 347,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://adobe.okta.com/app/office365/kxg149x5TOLQDOUEMHSP/sso/wsfed/mex"
+        },
+        "response": {
+          "bodySize": 26145,
+          "content": {
+            "mimeType": "text/xml;charset=utf-8",
+            "size": 26145,
+            "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><wsdl:definitions xmlns:wsdl='http://schemas.xmlsoap.org/wsdl/' xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:t='http://schemas.xmlsoap.org/ws/2005/02/trust' xmlns:soapenc='http://schemas.xmlsoap.org/soap/encoding/' xmlns:soap='http://schemas.xmlsoap.org/wsdl/soap/' xmlns:tns='http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice' xmlns:msc='http://schemas.microsoft.com/ws/2005/12/wsdl/contract' xmlns:wsam='http://www.w3.org/2007/05/addressing/metadata' xmlns:soap12='http://schemas.xmlsoap.org/wsdl/soap12/' xmlns:wsa='http://schemas.xmlsoap.org/ws/2004/08/addressing' xmlns:wsaw='http://www.w3.org/2006/05/addressing/wsdl' xmlns:wsap='http://schemas.xmlsoap.org/ws/2004/08/addressing/policy' xmlns:wsu='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd' xmlns:trust='http://docs.oasis-open.org/ws-sx/ws-trust/200512' xmlns:wsp='http://schemas.xmlsoap.org/ws/2004/09/policy' xmlns:wsa10='http://www.w3.org/2005/08/addressing' name='SecurityTokenService' targetNamespace='http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice'><wsp:Policy wsu:Id='CustomBinding_IWSTrustFeb2005Async_policy'><wsp:ExactlyOne><wsp:All><msis:DomainInternet xmlns:msis='http://schemas.microsoft.com/ws/2009/12/identityserver/'/><http:NegotiateAuthentication xmlns:http='http://schemas.microsoft.com/ws/06/2004/policy/http'/><sp:TransportBinding xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:TransportToken><wsp:Policy><sp:HttpsToken RequireClientCertificate='false'/></wsp:Policy></sp:TransportToken><sp:AlgorithmSuite><wsp:Policy><sp:Basic256/></wsp:Policy></sp:AlgorithmSuite><sp:Layout><wsp:Policy><sp:Strict/></wsp:Policy></sp:Layout></wsp:Policy></sp:TransportBinding><wsaw:UsingAddressing/></wsp:All></wsp:ExactlyOne></wsp:Policy><wsp:Policy wsu:Id='CertificateWSTrustBinding_IWSTrustFeb2005Async_policy'><wsp:ExactlyOne><wsp:All><sp:TransportBinding xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:TransportToken><wsp:Policy><sp:HttpsToken RequireClientCertificate='false'/></wsp:Policy></sp:TransportToken><sp:AlgorithmSuite><wsp:Policy><sp:Basic256/></wsp:Policy></sp:AlgorithmSuite><sp:Layout><wsp:Policy><sp:Strict/></wsp:Policy></sp:Layout><sp:IncludeTimestamp/></wsp:Policy></sp:TransportBinding><sp:EndorsingSupportingTokens xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:X509Token sp:IncludeToken='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient'><wsp:Policy><sp:RequireThumbprintReference/><sp:WssX509V3Token10/></wsp:Policy></sp:X509Token><mssp:RsaToken sp:IncludeToken='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never' wsp:Optional='true' xmlns:mssp='http://schemas.microsoft.com/ws/2005/07/securitypolicy'/><sp:SignedParts><sp:Header Name='To' Namespace='http://www.w3.org/2005/08/addressing'/></sp:SignedParts></wsp:Policy></sp:EndorsingSupportingTokens><sp:Wss11 xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:MustSupportRefKeyIdentifier/><sp:MustSupportRefIssuerSerial/><sp:MustSupportRefThumbprint/><sp:MustSupportRefEncryptedKey/></wsp:Policy></sp:Wss11><sp:Trust10 xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:MustSupportIssuedTokens/><sp:RequireClientEntropy/><sp:RequireServerEntropy/></wsp:Policy></sp:Trust10><wsaw:UsingAddressing/></wsp:All></wsp:ExactlyOne></wsp:Policy><wsp:Policy wsu:Id='CertificateWSTrustBinding_IWSTrustFeb2005Async1_policy'><wsp:ExactlyOne><wsp:All><sp:TransportBinding xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:TransportToken><wsp:Policy><sp:HttpsToken RequireClientCertificate='true'/></wsp:Policy></sp:TransportToken><sp:AlgorithmSuite><wsp:Policy><sp:Basic256/></wsp:Policy></sp:AlgorithmSuite><sp:Layout><wsp:Policy><sp:Strict/></wsp:Policy></sp:Layout></wsp:Policy></sp:TransportBinding><wsaw:UsingAddressing/></wsp:All></wsp:ExactlyOne></wsp:Policy><wsp:Policy wsu:Id='UserNameWSTrustBinding_IWSTrustFeb2005Async_policy'><wsp:ExactlyOne><wsp:All><sp:TransportBinding xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:TransportToken><wsp:Policy><sp:HttpsToken RequireClientCertificate='false'/></wsp:Policy></sp:TransportToken><sp:AlgorithmSuite><wsp:Policy><sp:Basic256/></wsp:Policy></sp:AlgorithmSuite><sp:Layout><wsp:Policy><sp:Strict/></wsp:Policy></sp:Layout><sp:IncludeTimestamp/></wsp:Policy></sp:TransportBinding><sp:SignedSupportingTokens xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:UsernameToken sp:IncludeToken='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient'><wsp:Policy><sp:WssUsernameToken10/></wsp:Policy></sp:UsernameToken></wsp:Policy></sp:SignedSupportingTokens><sp:EndorsingSupportingTokens xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><mssp:RsaToken sp:IncludeToken='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never' wsp:Optional='true' xmlns:mssp='http://schemas.microsoft.com/ws/2005/07/securitypolicy'/><sp:SignedParts><sp:Header Name='To' Namespace='http://www.w3.org/2005/08/addressing'/></sp:SignedParts></wsp:Policy></sp:EndorsingSupportingTokens><sp:Wss11 xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:MustSupportRefKeyIdentifier/><sp:MustSupportRefIssuerSerial/><sp:MustSupportRefThumbprint/><sp:MustSupportRefEncryptedKey/></wsp:Policy></sp:Wss11><sp:Trust10 xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:MustSupportIssuedTokens/><sp:RequireClientEntropy/><sp:RequireServerEntropy/></wsp:Policy></sp:Trust10><wsaw:UsingAddressing/></wsp:All></wsp:ExactlyOne></wsp:Policy><wsp:Policy wsu:Id='IssuedTokenWSTrustBinding_IWSTrustFeb2005Async_policy'><wsp:ExactlyOne><wsp:All><sp:TransportBinding xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:TransportToken><wsp:Policy><sp:HttpsToken RequireClientCertificate='false'/></wsp:Policy></sp:TransportToken><sp:AlgorithmSuite><wsp:Policy><sp:Basic256/></wsp:Policy></sp:AlgorithmSuite><sp:Layout><wsp:Policy><sp:Strict/></wsp:Policy></sp:Layout><sp:IncludeTimestamp/></wsp:Policy></sp:TransportBinding><sp:EndorsingSupportingTokens xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:IssuedToken sp:IncludeToken='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient'><sp:RequestSecurityTokenTemplate><t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/PublicKey</t:KeyType><t:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</t:EncryptWith><t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</t:SignatureAlgorithm><t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm><t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm></sp:RequestSecurityTokenTemplate><wsp:Policy><sp:RequireInternalReference/></wsp:Policy></sp:IssuedToken><mssp:RsaToken sp:IncludeToken='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never' wsp:Optional='true' xmlns:mssp='http://schemas.microsoft.com/ws/2005/07/securitypolicy'/><sp:SignedParts><sp:Header Name='To' Namespace='http://www.w3.org/2005/08/addressing'/></sp:SignedParts></wsp:Policy></sp:EndorsingSupportingTokens><sp:Wss11 xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:MustSupportRefKeyIdentifier/><sp:MustSupportRefIssuerSerial/><sp:MustSupportRefThumbprint/><sp:MustSupportRefEncryptedKey/></wsp:Policy></sp:Wss11><sp:Trust10 xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:MustSupportIssuedTokens/><sp:RequireClientEntropy/><sp:RequireServerEntropy/></wsp:Policy></sp:Trust10><wsaw:UsingAddressing/></wsp:All></wsp:ExactlyOne></wsp:Policy><wsp:Policy wsu:Id='IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1_policy'><wsp:ExactlyOne><wsp:All><sp:TransportBinding xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:TransportToken><wsp:Policy><sp:HttpsToken RequireClientCertificate='false'/></wsp:Policy></sp:TransportToken><sp:AlgorithmSuite><wsp:Policy><sp:Basic256/></wsp:Policy></sp:AlgorithmSuite><sp:Layout><wsp:Policy><sp:Strict/></wsp:Policy></sp:Layout><sp:IncludeTimestamp/></wsp:Policy></sp:TransportBinding><sp:EndorsingSupportingTokens xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:IssuedToken sp:IncludeToken='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient'><sp:RequestSecurityTokenTemplate><t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/SymmetricKey</t:KeyType><t:KeySize>256</t:KeySize><t:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptWith><t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</t:SignatureAlgorithm><t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm><t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm></sp:RequestSecurityTokenTemplate><wsp:Policy><sp:RequireInternalReference/></wsp:Policy></sp:IssuedToken><mssp:RsaToken sp:IncludeToken='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never' wsp:Optional='true' xmlns:mssp='http://schemas.microsoft.com/ws/2005/07/securitypolicy'/><sp:SignedParts><sp:Header Name='To' Namespace='http://www.w3.org/2005/08/addressing'/></sp:SignedParts></wsp:Policy></sp:EndorsingSupportingTokens><sp:Wss11 xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:MustSupportRefKeyIdentifier/><sp:MustSupportRefIssuerSerial/><sp:MustSupportRefThumbprint/><sp:MustSupportRefEncryptedKey/></wsp:Policy></sp:Wss11><sp:Trust10 xmlns:sp='http://schemas.xmlsoap.org/ws/2005/07/securitypolicy'><wsp:Policy><sp:MustSupportIssuedTokens/><sp:RequireClientEntropy/><sp:RequireServerEntropy/></wsp:Policy></sp:Trust10><wsaw:UsingAddressing/></wsp:All></wsp:ExactlyOne></wsp:Policy><wsp:Policy wsu:Id='CertificateWSTrustBinding_IWSTrust13Async_policy'><wsp:ExactlyOne><wsp:All><sp:TransportBinding xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:TransportToken><wsp:Policy><sp:HttpsToken/></wsp:Policy></sp:TransportToken><sp:AlgorithmSuite><wsp:Policy><sp:Basic256/></wsp:Policy></sp:AlgorithmSuite><sp:Layout><wsp:Policy><sp:Strict/></wsp:Policy></sp:Layout><sp:IncludeTimestamp/></wsp:Policy></sp:TransportBinding><sp:EndorsingSupportingTokens xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:X509Token sp:IncludeToken='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient'><wsp:Policy><sp:RequireThumbprintReference/><sp:WssX509V3Token10/></wsp:Policy></sp:X509Token><sp:KeyValueToken sp:IncludeToken='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never' wsp:Optional='true'/><sp:SignedParts><sp:Header Name='To' Namespace='http://www.w3.org/2005/08/addressing'/></sp:SignedParts></wsp:Policy></sp:EndorsingSupportingTokens><sp:Wss11 xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:MustSupportRefKeyIdentifier/><sp:MustSupportRefIssuerSerial/><sp:MustSupportRefThumbprint/><sp:MustSupportRefEncryptedKey/></wsp:Policy></sp:Wss11><sp:Trust13 xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:MustSupportIssuedTokens/><sp:RequireClientEntropy/><sp:RequireServerEntropy/></wsp:Policy></sp:Trust13><wsaw:UsingAddressing/></wsp:All></wsp:ExactlyOne></wsp:Policy><wsp:Policy wsu:Id='UserNameWSTrustBinding_IWSTrust13Async_policy'><wsp:ExactlyOne><wsp:All><sp:TransportBinding xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:TransportToken><wsp:Policy><sp:HttpsToken/></wsp:Policy></sp:TransportToken><sp:AlgorithmSuite><wsp:Policy><sp:Basic256/></wsp:Policy></sp:AlgorithmSuite><sp:Layout><wsp:Policy><sp:Strict/></wsp:Policy></sp:Layout><sp:IncludeTimestamp/></wsp:Policy></sp:TransportBinding><sp:SignedEncryptedSupportingTokens xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:UsernameToken sp:IncludeToken='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient'><wsp:Policy><sp:WssUsernameToken10/></wsp:Policy></sp:UsernameToken></wsp:Policy></sp:SignedEncryptedSupportingTokens><sp:EndorsingSupportingTokens xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:KeyValueToken sp:IncludeToken='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never' wsp:Optional='true'/><sp:SignedParts><sp:Header Name='To' Namespace='http://www.w3.org/2005/08/addressing'/></sp:SignedParts></wsp:Policy></sp:EndorsingSupportingTokens><sp:Wss11 xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:MustSupportRefKeyIdentifier/><sp:MustSupportRefIssuerSerial/><sp:MustSupportRefThumbprint/><sp:MustSupportRefEncryptedKey/></wsp:Policy></sp:Wss11><sp:Trust13 xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:MustSupportIssuedTokens/><sp:RequireClientEntropy/><sp:RequireServerEntropy/></wsp:Policy></sp:Trust13><wsaw:UsingAddressing/></wsp:All></wsp:ExactlyOne></wsp:Policy><wsp:Policy wsu:Id='IssuedTokenWSTrustBinding_IWSTrust13Async_policy'><wsp:ExactlyOne><wsp:All><sp:TransportBinding xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:TransportToken><wsp:Policy><sp:HttpsToken/></wsp:Policy></sp:TransportToken><sp:AlgorithmSuite><wsp:Policy><sp:Basic256/></wsp:Policy></sp:AlgorithmSuite><sp:Layout><wsp:Policy><sp:Strict/></wsp:Policy></sp:Layout><sp:IncludeTimestamp/></wsp:Policy></sp:TransportBinding><sp:EndorsingSupportingTokens xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:IssuedToken sp:IncludeToken='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient'><sp:RequestSecurityTokenTemplate><trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/PublicKey</trust:KeyType><trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm><trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:EncryptWith><trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</trust:SignatureAlgorithm><trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm><trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm></sp:RequestSecurityTokenTemplate><wsp:Policy><sp:RequireInternalReference/></wsp:Policy></sp:IssuedToken><sp:KeyValueToken sp:IncludeToken='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never' wsp:Optional='true'/><sp:SignedParts><sp:Header Name='To' Namespace='http://www.w3.org/2005/08/addressing'/></sp:SignedParts></wsp:Policy></sp:EndorsingSupportingTokens><sp:Wss11 xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:MustSupportRefKeyIdentifier/><sp:MustSupportRefIssuerSerial/><sp:MustSupportRefThumbprint/><sp:MustSupportRefEncryptedKey/></wsp:Policy></sp:Wss11><sp:Trust13 xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:MustSupportIssuedTokens/><sp:RequireClientEntropy/><sp:RequireServerEntropy/></wsp:Policy></sp:Trust13><wsaw:UsingAddressing/></wsp:All></wsp:ExactlyOne></wsp:Policy><wsp:Policy wsu:Id='IssuedTokenWSTrustBinding_IWSTrust13Async1_policy'><wsp:ExactlyOne><wsp:All><sp:TransportBinding xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:TransportToken><wsp:Policy><sp:HttpsToken/></wsp:Policy></sp:TransportToken><sp:AlgorithmSuite><wsp:Policy><sp:Basic256/></wsp:Policy></sp:AlgorithmSuite><sp:Layout><wsp:Policy><sp:Strict/></wsp:Policy></sp:Layout><sp:IncludeTimestamp/></wsp:Policy></sp:TransportBinding><sp:EndorsingSupportingTokens xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:IssuedToken sp:IncludeToken='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient'><sp:RequestSecurityTokenTemplate><trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/SymmetricKey</trust:KeyType><trust:KeySize>256</trust:KeySize><trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm><trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptWith><trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</trust:SignatureAlgorithm><trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm><trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm></sp:RequestSecurityTokenTemplate><wsp:Policy><sp:RequireInternalReference/></wsp:Policy></sp:IssuedToken><sp:KeyValueToken sp:IncludeToken='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never' wsp:Optional='true'/><sp:SignedParts><sp:Header Name='To' Namespace='http://www.w3.org/2005/08/addressing'/></sp:SignedParts></wsp:Policy></sp:EndorsingSupportingTokens><sp:Wss11 xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:MustSupportRefKeyIdentifier/><sp:MustSupportRefIssuerSerial/><sp:MustSupportRefThumbprint/><sp:MustSupportRefEncryptedKey/></wsp:Policy></sp:Wss11><sp:Trust13 xmlns:sp='http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702'><wsp:Policy><sp:MustSupportIssuedTokens/><sp:RequireClientEntropy/><sp:RequireServerEntropy/></wsp:Policy></sp:Trust13><wsaw:UsingAddressing/></wsp:All></wsp:ExactlyOne></wsp:Policy><wsdl:types><xsd:schema targetNamespace='http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice/Imports'><xsd:import schemaLocation='https://adobe.okta.com/assets/components/schema/office365/xsd0.xsd' namespace='http://schemas.microsoft.com/Message'/><xsd:import schemaLocation='https://adobe.okta.com/assets/components/schema/office365/xsd1.xsd' namespace='http://schemas.xmlsoap.org/ws/2005/02/trust'/><xsd:import schemaLocation='https://adobe.okta.com/assets/components/schema/office365/xsd2.xsd' namespace='http://docs.oasis-open.org/ws-sx/ws-trust/200512'/></xsd:schema></wsdl:types><wsdl:message name='IWSTrustFeb2005Async_TrustFeb2005IssueAsync_InputMessage'><wsdl:part name='request' element='t:RequestSecurityToken'/></wsdl:message><wsdl:message name='IWSTrustFeb2005Async_TrustFeb2005IssueAsync_OutputMessage'><wsdl:part name='TrustFeb2005IssueAsyncResult' element='t:RequestSecurityTokenResponse'/></wsdl:message><wsdl:message name='IWSTrust13Async_Trust13IssueAsync_InputMessage'><wsdl:part name='request' element='trust:RequestSecurityToken'/></wsdl:message><wsdl:message name='IWSTrust13Async_Trust13IssueAsync_OutputMessage'><wsdl:part name='Trust13IssueAsyncResult' element='trust:RequestSecurityTokenResponseCollection'/></wsdl:message><wsdl:portType name='IWSTrustFeb2005Async'><wsdl:operation name='TrustFeb2005IssueAsync'><wsdl:input wsaw:Action='http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue' message='tns:IWSTrustFeb2005Async_TrustFeb2005IssueAsync_InputMessage'/><wsdl:output wsaw:Action='http://schemas.xmlsoap.org/ws/2005/02/trust/RSTR/Issue' message='tns:IWSTrustFeb2005Async_TrustFeb2005IssueAsync_OutputMessage'/></wsdl:operation></wsdl:portType><wsdl:portType name='IWSTrust13Async'><wsdl:operation name='Trust13IssueAsync'><wsdl:input wsaw:Action='http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue' message='tns:IWSTrust13Async_Trust13IssueAsync_InputMessage'/><wsdl:output wsaw:Action='http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTRC/IssueFinal' message='tns:IWSTrust13Async_Trust13IssueAsync_OutputMessage'/></wsdl:operation></wsdl:portType><wsdl:binding name='CustomBinding_IWSTrustFeb2005Async' type='tns:IWSTrustFeb2005Async'><wsp:PolicyReference URI='#CustomBinding_IWSTrustFeb2005Async_policy'/><soap12:binding transport='http://schemas.xmlsoap.org/soap/http'/><wsdl:operation name='TrustFeb2005IssueAsync'><soap12:operation soapAction='http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue' style='document'/><wsdl:input><soap12:body use='literal'/></wsdl:input><wsdl:output><soap12:body use='literal'/></wsdl:output></wsdl:operation></wsdl:binding><wsdl:binding name='CertificateWSTrustBinding_IWSTrustFeb2005Async' type='tns:IWSTrustFeb2005Async'><wsp:PolicyReference URI='#CertificateWSTrustBinding_IWSTrustFeb2005Async_policy'/><soap12:binding transport='http://schemas.xmlsoap.org/soap/http'/><wsdl:operation name='TrustFeb2005IssueAsync'><soap12:operation soapAction='http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue' style='document'/><wsdl:input><soap12:body use='literal'/></wsdl:input><wsdl:output><soap12:body use='literal'/></wsdl:output></wsdl:operation></wsdl:binding><wsdl:binding name='CertificateWSTrustBinding_IWSTrustFeb2005Async1' type='tns:IWSTrustFeb2005Async'><wsp:PolicyReference URI='#CertificateWSTrustBinding_IWSTrustFeb2005Async1_policy'/><soap12:binding transport='http://schemas.xmlsoap.org/soap/http'/><wsdl:operation name='TrustFeb2005IssueAsync'><soap12:operation soapAction='http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue' style='document'/><wsdl:input><soap12:body use='literal'/></wsdl:input><wsdl:output><soap12:body use='literal'/></wsdl:output></wsdl:operation></wsdl:binding><wsdl:binding name='UserNameWSTrustBinding_IWSTrustFeb2005Async' type='tns:IWSTrustFeb2005Async'><wsp:PolicyReference URI='#UserNameWSTrustBinding_IWSTrustFeb2005Async_policy'/><soap12:binding transport='http://schemas.xmlsoap.org/soap/http'/><wsdl:operation name='TrustFeb2005IssueAsync'><soap12:operation soapAction='http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue' style='document'/><wsdl:input><soap12:body use='literal'/></wsdl:input><wsdl:output><soap12:body use='literal'/></wsdl:output></wsdl:operation></wsdl:binding><wsdl:binding name='IssuedTokenWSTrustBinding_IWSTrustFeb2005Async' type='tns:IWSTrustFeb2005Async'><wsp:PolicyReference URI='#IssuedTokenWSTrustBinding_IWSTrustFeb2005Async_policy'/><soap12:binding transport='http://schemas.xmlsoap.org/soap/http'/><wsdl:operation name='TrustFeb2005IssueAsync'><soap12:operation soapAction='http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue' style='document'/><wsdl:input><soap12:body use='literal'/></wsdl:input><wsdl:output><soap12:body use='literal'/></wsdl:output></wsdl:operation></wsdl:binding><wsdl:binding name='IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1' type='tns:IWSTrustFeb2005Async'><wsp:PolicyReference URI='#IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1_policy'/><soap12:binding transport='http://schemas.xmlsoap.org/soap/http'/><wsdl:operation name='TrustFeb2005IssueAsync'><soap12:operation soapAction='http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue' style='document'/><wsdl:input><soap12:body use='literal'/></wsdl:input><wsdl:output><soap12:body use='literal'/></wsdl:output></wsdl:operation></wsdl:binding><wsdl:binding name='CertificateWSTrustBinding_IWSTrust13Async' type='tns:IWSTrust13Async'><wsp:PolicyReference URI='#CertificateWSTrustBinding_IWSTrust13Async_policy'/><soap12:binding transport='http://schemas.xmlsoap.org/soap/http'/><wsdl:operation name='Trust13IssueAsync'><soap12:operation soapAction='http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue' style='document'/><wsdl:input><soap12:body use='literal'/></wsdl:input><wsdl:output><soap12:body use='literal'/></wsdl:output></wsdl:operation></wsdl:binding><wsdl:binding name='UserNameWSTrustBinding_IWSTrust13Async' type='tns:IWSTrust13Async'><wsp:PolicyReference URI='#UserNameWSTrustBinding_IWSTrust13Async_policy'/><soap12:binding transport='http://schemas.xmlsoap.org/soap/http'/><wsdl:operation name='Trust13IssueAsync'><soap12:operation soapAction='http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue' style='document'/><wsdl:input><soap12:body use='literal'/></wsdl:input><wsdl:output><soap12:body use='literal'/></wsdl:output></wsdl:operation></wsdl:binding><wsdl:binding name='IssuedTokenWSTrustBinding_IWSTrust13Async' type='tns:IWSTrust13Async'><wsp:PolicyReference URI='#IssuedTokenWSTrustBinding_IWSTrust13Async_policy'/><soap12:binding transport='http://schemas.xmlsoap.org/soap/http'/><wsdl:operation name='Trust13IssueAsync'><soap12:operation soapAction='http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue' style='document'/><wsdl:input><soap12:body use='literal'/></wsdl:input><wsdl:output><soap12:body use='literal'/></wsdl:output></wsdl:operation></wsdl:binding><wsdl:binding name='IssuedTokenWSTrustBinding_IWSTrust13Async1' type='tns:IWSTrust13Async'><wsp:PolicyReference URI='#IssuedTokenWSTrustBinding_IWSTrust13Async1_policy'/><soap12:binding transport='http://schemas.xmlsoap.org/soap/http'/><wsdl:operation name='Trust13IssueAsync'><soap12:operation soapAction='http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue' style='document'/><wsdl:input><soap12:body use='literal'/></wsdl:input><wsdl:output><soap12:body use='literal'/></wsdl:output></wsdl:operation></wsdl:binding><wsdl:service name='SecurityTokenService'><wsdl:port name='UserNameWSTrustBinding_IWSTrustFeb2005Async' binding='tns:UserNameWSTrustBinding_IWSTrustFeb2005Async'><soap12:address location='https://adobe.okta.com/app/office365/kxg149x5TOLQDOUEMHSP/sso/wsfed/active'/><wsa10:EndpointReference><wsa10:Address>https://adobe.okta.com/app/office365/kxg149x5TOLQDOUEMHSP/sso/wsfed/active</wsa10:Address></wsa10:EndpointReference></wsdl:port><wsdl:port name='UserNameWSTrustBinding_IWSTrust13Async' binding='tns:UserNameWSTrustBinding_IWSTrust13Async'><soap12:address location='https://adobe.okta.com/app/office365/kxg149x5TOLQDOUEMHSP/sso/wsfed/username13'/><wsa10:EndpointReference><wsa10:Address>https://adobe.okta.com/app/office365/kxg149x5TOLQDOUEMHSP/sso/wsfed/username13</wsa10:Address></wsa10:EndpointReference></wsdl:port></wsdl:service></wsdl:definitions>"
+          },
+          "cookies": [
+            {
+              "expires": "1970-01-01T00:00:10.000Z",
+              "name": "sid",
+              "path": "/",
+              "value": "\"\""
+            },
+            {
+              "httpOnly": true,
+              "name": "JSESSIONID",
+              "path": "/",
+              "secure": true,
+              "value": "582EC35E42E482B89D130F6E142C0F47"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 15 Apr 2021 05:53:26 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/xml;charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "public-key-pins-report-only",
+              "value": "pin-sha256=\"r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8=\"; pin-sha256=\"MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=\"; pin-sha256=\"72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI=\"; pin-sha256=\"rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=\"; max-age=60; report-uri=\"https://okta.report-uri.com/r/default/hpkp/reportOnly\""
+            },
+            {
+              "name": "x-okta-request-id",
+              "value": "YHfU1vz-ciFuReItXM5dPwAAAjI"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"HONK\""
+            },
+            {
+              "name": "x-rate-limit-limit",
+              "value": "5000"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "4986"
+            },
+            {
+              "name": "x-rate-limit-reset",
+              "value": "1618466030"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "default-src 'self' *.oktacdn.com adobe.okta.com *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net; connect-src 'self' *.oktacdn.com *.mixpanel.com *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com adobe.okta.com adobe-admin.okta.com adobe.kerberos.okta.com https://oinmanager.okta.com data: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net; script-src 'unsafe-inline' 'unsafe-eval' 'self' *.oktacdn.com *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net; style-src 'unsafe-inline' 'self' *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net; frame-src 'self' login.okta.com adobe.okta.com adobe-admin.okta.com *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net; img-src 'self' *.oktacdn.com adobe.okta.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net; font-src data: 'self' *.oktacdn.com fonts.gstatic.com *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net"
+            },
+            {
+              "name": "expect-ct",
+              "value": "report-uri=\"https://oktaexpectct.report-uri.com/r/t/ct/reportOnly\", max-age=0"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=315360000; includeSubDomains"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sid=\"\"; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "JSESSIONID=582EC35E42E482B89D130F6E142C0F47; Path=/; Secure; HttpOnly"
+            }
+          ],
+          "headersSize": 2387,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-04-15T05:53:25.842Z",
+        "time": 902,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 902
+        }
+      },
+      {
+        "_id": "ac5ea8a7cd215f022c5b08d004a1132c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1815,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/soap+xml; charset=utf-8"
+            },
+            {
+              "name": "soapaction",
+              "value": "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "13e5dcce-917a-4459-b183-64d6b9be24a4"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.2.1-patch.0"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "adobe.okta.com"
+            },
+            {
+              "name": "content-length",
+              "value": 1815
+            }
+          ],
+          "headersSize": 464,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [],
+          "url": "https://adobe.okta.com/app/office365/kxg149x5TOLQDOUEMHSP/sso/wsfed/username13"
+        },
+        "response": {
+          "bodySize": 6577,
+          "content": {
+            "mimeType": "application/soap+xml;charset=utf-8",
+            "size": 6577,
+            "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><s:Envelope xmlns:s=\"http://www.w3.org/2003/05/soap-envelope\"><s:Header><wsa:Action xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTRC/IssueFinal</wsa:Action><wsa:RelatesTo RelationshipType=\"http://www.w3.org/2005/08/addressing/reply\" xmlns:wsa=\"http://www.w3.org/2005/08/addressing\"/><wsa:To xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">http://www.w3.org/2005/08/addressing/anonymous</wsa:To><wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"><wsu:Timestamp xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\"><wsu:Created>2021-04-15T05:48:27.556Z</wsu:Created><wsu:Expires>2021-04-15T05:58:27.556Z</wsu:Expires></wsu:Timestamp></wsse:Security></s:Header><s:Body><wst:RequestSecurityTokenResponseCollection xmlns:wst=\"http://docs.oasis-open.org/ws-sx/ws-trust/200512\"><wst:RequestSecurityTokenResponse><wst:Lifetime><wsu:Created xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\">2021-04-15T05:48:27.556Z</wsu:Created><wsu:Expires xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\">2021-04-15T07:53:27.556Z</wsu:Expires></wst:Lifetime><wst:TokenType>urn:oasis:names:tc:SAML:1.0:assertion</wst:TokenType><wst:RequestType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Issue</wst:RequestType><wst:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer</wst:KeyType><wsp:AppliesTo xmlns:wsp=\"http://schemas.xmlsoap.org/ws/2004/09/policy\"><wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\"><wsa:Address>urn:federation:MicrosoftOnline</wsa:Address></wsa:EndpointReference></wsp:AppliesTo><wst:RequestedSecurityToken><saml1:Assertion AssertionID=\"aid34601142122654887\" IssueInstant=\"2021-04-15T05:53:27.556Z\" Issuer=\"kxg149x5TOLQDOUEMHSP\" MajorVersion=\"1\" MinorVersion=\"1\" xmlns:saml1=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"><saml1:Conditions NotBefore=\"2021-04-15T05:48:27.556Z\" NotOnOrAfter=\"2021-04-15T07:53:27.556Z\"><saml1:AudienceRestrictionCondition><saml1:Audience>urn:federation:MicrosoftOnline</saml1:Audience></saml1:AudienceRestrictionCondition></saml1:Conditions><saml1:AuthenticationStatement AuthenticationInstant=\"2021-04-15T05:53:27.556Z\" AuthenticationMethod=\"urn:oasis:names:tc:SAML:1.0:am:password\"><saml1:Subject><saml1:NameIdentifier Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\">Eoom9TDMo0+9npelshlAMw==</saml1:NameIdentifier><saml1:SubjectConfirmation><saml1:ConfirmationMethod>urn:oasis:names:tc:SAML:1.0:cm:bearer</saml1:ConfirmationMethod></saml1:SubjectConfirmation></saml1:Subject></saml1:AuthenticationStatement><saml1:AttributeStatement><saml1:Subject><saml1:NameIdentifier Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\">Eoom9TDMo0+9npelshlAMw==</saml1:NameIdentifier><saml1:SubjectConfirmation><saml1:ConfirmationMethod>urn:oasis:names:tc:SAML:1.0:cm:bearer</saml1:ConfirmationMethod></saml1:SubjectConfirmation></saml1:Subject><saml1:Attribute AttributeName=\"UPN\" AttributeNamespace=\"http://schemas.xmlsoap.org/claims\"><saml1:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"xs:string\">helix@adobe.com</saml1:AttributeValue></saml1:Attribute><saml1:Attribute AttributeName=\"ImmutableID\" AttributeNamespace=\"http://schemas.microsoft.com/LiveID/Federation/2008/05\"><saml1:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"xs:string\">Eoom9TDMo0+9npelshlAMw==</saml1:AttributeValue></saml1:Attribute></saml1:AttributeStatement><ds:Signature xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:SignedInfo><ds:CanonicalizationMethod Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/><ds:SignatureMethod Algorithm=\"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256\"/><ds:Reference URI=\"#aid34601142122654887\"><ds:Transforms><ds:Transform Algorithm=\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\"/><ds:Transform Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"><ec:InclusiveNamespaces PrefixList=\"xs\" xmlns:ec=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/></ds:Transform></ds:Transforms><ds:DigestMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#sha256\"/><ds:DigestValue>sPTyP2FiP80N08PgHg31V+BaWSXofbv1JjCLGYVxK3I=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>Zb75ngTu2Oc53x5IuHqMk3vzQFomevbKghx4KLlpVD3kNX1FOUgoHQSDhDFYSKqTaqNiCnPhdxG3wwpD0N7VKp7f8tcYFsOMrircjyXwFxz03oZDWgN3QiMxbx+HpQpKfYRcjyzV18nQ1+LhzbvA4e4Ka0E7NZQOlxQqOvX/Qb0=</ds:SignatureValue><ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIICoTCCAgqgAwIBAgIGAUfVQdUCMA0GCSqGSIb3DQEBBQUAMIGTMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxFDASBgNVBAMMC2Fkb2JlLXN0YWdlMRwwGgYJKoZIhvcNAQkB\nFg1pbmZvQG9rdGEuY29tMB4XDTE0MDgxNDE2MDE0N1oXDTQ0MDgxNDE2MDI0N1owgZMxCzAJBgNV\nBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYD\nVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEUMBIGA1UEAwwLYWRvYmUtc3RhZ2UxHDAa\nBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAJjO\nKmtvBdbtiCGWNvYIniAmMs5ZXn3/X6IWjimOP7t49PbpNAv+7CMEDl2uqZf6yglp6NkhaE5Gkj4a\nhuPAnwOgEp3ohtNUCv8pBbthydjXvlRp/WCy/5a1nBd58xdqPbwkOxkmzcn1Q54eblvaV2PNTv8h\nkw7SMXeabHPMjXMvAgMBAAEwDQYJKoZIhvcNAQEFBQADgYEAZ80++rL7i426dcj/OsuF8YNhunHr\nuumsL7WMdM3tUhi/m/vxB32FNQ5fCiuLAZeINnXZNhM7Py8eushU+VnqXEMwTMDw3DFtDZi/PVUm\nHzXwB5dTQM0BTBhtWDUHuXOF7GW7+2voZgwAQkgA5DvpNeoO6QXxvONl4MR+mP+QxIY=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></ds:Signature></saml1:Assertion></wst:RequestedSecurityToken><wst:RequestedAttachedReference><wsse:SecurityTokenReference xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"><wsse:KeyIdentifier ValueType=\"http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.0#SAMLAssertionID\">aid34601142122654887</wsse:KeyIdentifier></wsse:SecurityTokenReference></wst:RequestedAttachedReference><wst:RequestedUnattachedReference><wsse:SecurityTokenReference xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"><wsse:KeyIdentifier ValueType=\"http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.0#SAMLAssertionID\">aid34601142122654887</wsse:KeyIdentifier></wsse:SecurityTokenReference></wst:RequestedUnattachedReference></wst:RequestSecurityTokenResponse></wst:RequestSecurityTokenResponseCollection></s:Body></s:Envelope>"
+          },
+          "cookies": [
+            {
+              "expires": "1970-01-01T00:00:10.000Z",
+              "name": "sid",
+              "path": "/",
+              "value": "\"\""
+            },
+            {
+              "httpOnly": true,
+              "name": "JSESSIONID",
+              "path": "/",
+              "secure": true,
+              "value": "504DD4F0006DA61BE5A7E4A729CA6C05"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 15 Apr 2021 05:53:27 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/soap+xml;charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "6577"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "public-key-pins-report-only",
+              "value": "pin-sha256=\"r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8=\"; pin-sha256=\"MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=\"; pin-sha256=\"72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI=\"; pin-sha256=\"rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=\"; max-age=60; report-uri=\"https://okta.report-uri.com/r/default/hpkp/reportOnly\""
+            },
+            {
+              "name": "x-okta-request-id",
+              "value": "YHfU11lcdD9kTaeojnR45AAACUY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"HONK\""
+            },
+            {
+              "name": "x-rate-limit-limit",
+              "value": "2000"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "1999"
+            },
+            {
+              "name": "x-rate-limit-reset",
+              "value": "1618466067"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "default-src 'self' *.oktacdn.com adobe.okta.com *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net; connect-src 'self' *.oktacdn.com *.mixpanel.com *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com adobe.okta.com adobe-admin.okta.com adobe.kerberos.okta.com https://oinmanager.okta.com data: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net; script-src 'unsafe-inline' 'unsafe-eval' 'self' *.oktacdn.com *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net; style-src 'unsafe-inline' 'self' *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net; frame-src 'self' login.okta.com adobe.okta.com adobe-admin.okta.com *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net; img-src 'self' *.oktacdn.com adobe.okta.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net; font-src data: 'self' *.oktacdn.com fonts.gstatic.com *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net"
+            },
+            {
+              "name": "expect-ct",
+              "value": "report-uri=\"https://oktaexpectct.report-uri.com/r/t/ct/reportOnly\", max-age=0"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=315360000; includeSubDomains"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sid=\"\"; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "JSESSIONID=504DD4F0006DA61BE5A7E4A729CA6C05; Path=/; Secure; HttpOnly"
+            }
+          ],
+          "headersSize": 2393,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-04-15T05:53:26.788Z",
+        "time": 861,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 861
+        }
+      },
+      {
+        "_id": "6c569acd22c5a88c4a1f0bd619afec8a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 5390,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept-charset",
+              "value": "utf-8"
+            },
+            {
+              "name": "client-request-id",
+              "value": "13e5dcce-917a-4459-b183-64d6b9be24a4"
+            },
+            {
+              "name": "return-client-request-id",
+              "value": "true"
+            },
+            {
+              "name": "x-client-sku",
+              "value": "Node"
+            },
+            {
+              "name": "x-client-ver",
+              "value": "0.2.1-patch.0"
+            },
+            {
+              "name": "x-client-os",
+              "value": "darwin"
+            },
+            {
+              "name": "x-client-cpu",
+              "value": "x64"
+            },
+            {
+              "name": "host",
+              "value": "login.windows.net"
+            },
+            {
+              "name": "content-length",
+              "value": 5390
+            }
+          ],
+          "headersSize": 376,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "api-version",
+              "value": "1.0"
+            }
+          ],
+          "url": "https://login.windows.net/common/oauth2/token?api-version=1.0"
+        },
+        "response": {
+          "bodySize": 4648,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 4648,
+            "text": "{\"token_type\":\"Bearer\",\"scope\":\"Files.ReadWrite.All MyFiles.Read Sites.ReadWrite.All User.Read\",\"expires_in\":\"3599\",\"ext_expires_in\":\"3599\",\"expires_on\":\"1618469607\",\"not_before\":\"1618465707\",\"resource\":\"https://graph.microsoft.com\",\"access_token\":\"aaA0aAAaAaAAA0AaAAAaa00aAAA0Aa0AAAAaAaAaAAAaAaA0A0A0AAAaAaa0aAaAA0AaA0AAAaaaaAAAA0AaaAaaAAAaaAaaAaAAAaA0AaAaAaa0aAA0Aa0AaaAaAAAAAAaAAaAaA0aaAAAaAAAaA0aAAaAaAaaaAAA0Aa0AaaAaAAAAAAaAAaAaA0aaAAAaAAAaA0aAAaA0.aaAaaAAaAaAaaAAaaaaaA0aaAAAaAa0aA0Aaa00aaA0aa00aAAAaa0AaAaAaaAAaaaaaA0A0aa00aA0aa0aaAa0aaA0aAAaaAAA0AA00AaA0AAAaAAaaAAAaAA0aAaAaAaaaAAAaAAAaAaaaaAA0AaaaAaA0AAA0AaA0AAAaAaAaAaA0AAa0AaA0AAaaAaA0aAA0AAAaAAA0AAAaAaaaAAAaaAA0AAaaAAAaAaaaAAAaAaAaaaAaAaaaaAAaAaAaAAA0aaAaaAA0AAAaAAA0aaa0aAaaAa0aAAA0aa00aAaaaa0aa0A0AaAaaAAaAAA0aa00aAaaaa0aa0A0AaAaaAAaAAA0aa00aAaaaa0aa0A0AaAaaAAaAAAaAAAaAaAaAaaaAaAaAAAaAAAaAaA0AaaaAaAaAAAaAaAaAaA0AaaaAaaaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAAaAAaaAAAaAAaaAAAaAAaaAAAaAaAaAAAaAaAaAAAaAaAaAAAaAaAaAAAaAaAaAAAaAaAaAAaaAAaaAaaaAAAaA0aAAA0AAaaAaAAaAaaAaAAaAa0AAaAAaaaAaAAaaaaaaAAaaAAAA0AAA0A0AA0aAAAaAaAaaaA0AaAaa0AaAAaaAAAaA0Aaa0AaAAaaAA0aAaaaAAAaaAaaAA0aAa0aaaaaa0aaAAAaaaAaA0AaAAAaaAAaAAA0AaaaAAAaAAAaAAAaAAAaAAA0AA00AaAaAAAaAAAaAaA0Aaa0AaAaAaAaaAaaAAAaAaaaAAAaAaAaaAaaaA0aAA0aAaaaAAAaaAaaAA00AAaaAAAaa00aAAAaaAAaaa0aAA0aAaaaAAAaaaAaaAAaAaaaaAaaAaaaaAAaaaAaAaaaAAAaaaA0AaAaAa00Aa0aAAAaAAaaAAAaAA0aAaaaAAAaaaAaaAAAAAaaaAAAaaAaA0AaaAaaaaAaAa0aAAA0AaA0AaAaAaAaAAA0AAaaAAAaAA00AAAaAAA0AaaaAAAaA0AaAAAaAa0aaAAaaA0aaAAaAaAAAAAaAA0aAA00AaA0Aaa0AAAaAaAaAAA0AAA0AA00Aaa0AAAaAAAaAaAaAAAaAaaaaAaaaAAaAaAaAAAaAaA0aAAaAaAaAAAaAaAaAAaAAAA0AaAAAaaaaaaaAaAaAaAAAAAAaAA0AAaAA0aaA0AaaAaAAA00AaAAAAAaAA0AAAAaA0a0AAA0AAaAA0AAaAAAAA0aAAAaA0AaAaAAaAaaaa0AAAAaA0AaaAAaAAaaAA00AaaaAAAaAaAaAAAAaAAaaa0AAAAaA0AaaAAaAAaaAAAaAAAaAaAaAAAaAaA0AaA0AaAaaAaaaA0AAAAaaAaAaAaaAaaaaAaAa0A0AAaaAAAaAA0Aaa0AaaAaA00aAAA0AA0aaaAaaaAaaA0aA0Aaa0AaAaaaA0aaAAA0aAAaAaAaAAaaAAA0AA00AaA0AAAaAAaaAAAaAA0aAaAaAaaaAAAaAAAaAAA0aaaaaAAaaaAaAAA0AaaaaAa0AAAaa0AaAaAaaAAaAaAaaaA0AaaaaAa0AAAaa0AaAaAaaAAaAaA0aAA0AaAAaaAaAAAAAAa0AAAaAAaaaAaAAAAaAAA0AAAaAaAaAaAaAAA0aAAaAaaaAaA0AAAaAaAaAAAaAaaaAAA0AA00AAAaAAa0AaA0AAA0AAAaAAAaAAA0aAAaaAAaaAA0AAA0AAaaAaa0AA0.A0aAAAaAa_aaAAaAaAAaaAaaaaAAaaAAa0AAaA0AaA0aaAaaaAAAAa0aa0AAAAaA0aaAaAAAAAaaa0Aa00Aaaa0aaaaaAaaAaaa00aaAAAA0aaAaAaaAAaA0Aaa-AaaaA0aaAA0A00AAAaA0_0aA0a0AaaaAA0aAa0Aa0AAaAA0aaaaaaAaaaAAaa-0aA0-A-Aa00AaaAa00aAaAAAa0aaAaAaA0AA_Aaa_Aaa00A0AAaaaA00aAaaA0Aa0aa-Aaaa0AAa0Aa_A0AaAaAAAAAaAAAAAaAa0aaAAAA0a0AA0aAaAAaAaAAaAAAaaA0aAA00aaA0aaaAA0AaA0AaaAaa\",\"refresh_token\":\"0.AAAAAaa0-aA0a0AAaaAAaA0A0AAaa0AAA00AaaAA0A0AAAAaAA0.AaAAAAAAAAA--AAA0AA0AaaaaAa0AaaaAaAa_aAA0A_0a0AaA-aAaaAaa0A0aAA0A0a0A0A-AaAAA-aAAa0AaAaAaAaAaAaAa0-AaAAAaaAaa00Aa0AAaAAAaAA_aAAAA0aaAaAaaAaAAaAAAAAAAa0aAaAaAaAAa_0a-AaaaaAaAa-00aaaAa0aaaAAaAaaA0A0aAaAA_aAaAA-A0AAaaaaaaAaaaAA000aAAaAAa00aAaA00AaaAaAAaAAAaAaAaa-0Aa0aa0-aAA00aaaaaaAA00a_00AaaaAaAaaaA0AA0AA0Aa00Aaa0aa-AA00aaAAAaAAAaaAAAAAAaA-aA0aAAAA00aaaAaAaAaAAAaa0A-Aaa0A0aaAaaAAA00aAa00AaAa_0aAaA00AA00AAa-aaa-0AA0AAaA-0aAaaaaaaaAa00aaAa0a0AAaaa0a0AAAAAAAAAAaaaAaA0AA0a0aA0AAaA0aA0aA-aaaaaaA-a00AAaaaA0AAAaAaAaAaAAAAaaaAaaA00AAAAAAAaAaAAaaaAaAaAAAaAAaaa0aa0aAAAAaAaAaaA_aaAA0aAa0aA0AA_AaaAa-aAa00a0aAAaaaA0A0a00A0AAaAaAaaaaaA_AAaaAAA0a0AaAaaAaAaa0AAaaAaaa0AAaAA_0aAaaAAaaaaaaA0aA0-aAaAAAaaaAaaAAaaaAAAA0aa0aaaAAAAa0a0aAA0aAaAA0A0aaaAaAAaAAa0AaAaAaA0a-aAA0-0A0AaaaA0AaAA0A0aAAAAaAaAAaaa0AaA0aaaAA0AAaA0AA-aaAA-0aAAAAaAa00AAAa0aA00aaaAaAaA0_aAaAa0AaAAAAAAaAA0A0a0Aa0aaaAAAAAAaaaAAAaaAAaAA00AaAAaAaAAaA0AaaAAAAa0aaAaAa0aAAA0AAAAaaA0AA0aa-aaaAaaaaAa0aaAAaAAa0aaAAA0AaaaaAaAaAaaAaaAaaAaaAaaAAa0aaAAAa0A00AAAaAaAAaaaAaAaA0AAa0aAAAaAaaAAAA0aAAaaAa0aAAaaaaAA0AaAaAAaaaAaAaaAaA0A0a0AAAa0aaAaAaaaAAAa_AAaaaaaa_AaaAaa0AaaAa0_AA0aA0AAAaaaaAA0aA0\",\"id_token\":\"aaA0aAAaAaAAA0AaAAAaaAaaAaAaa00aAa0.aaAaaAAaAaA0A0AaAaaaAa00AaAaAAAaAAAaAAAaAa0aAAAaAaAaAAA0AAAaAAAaa0AaAaAaaAAaaaaaA0A0aa00aA0aa0aaAa0aaA0aAAaaAAA0AA00AaA0AAAaAAaaAAAaAA0aAaAaAaaaAAAaAAAaAaaaaAA0AaaaAaA0AAA0AaA0AAAaAaAaAaA0AAa0AaA0AAaaAaA0aAA0AAAaAAA0AAAaAaaaAA0aAaaaAaA0AAAaAAAaAA0aaAaaaaAaAAA0AaaaaAa0AAaaaAAaaaA0aA0aAaaaA0a0AA0aaaAaAAA0AaAaa0aaA0AaAAAaaAAaAAAaAaAaAAAaAAAaAaA0AaA0AaaaaaAaAAA0AaAaa0aaA0AaAAAaaAaaAA00AAaaAAAaa00aAAAaaAAaAaAaAAAaA0AaAa00AAa0AAA0AaaaAAAaAA0aAaa0AaaaAaaaA0AaAAAaaaAaAA0aa0aaAaaaAa0aAAAaAaAaAaAaAAa0AaA0AAAaAaA0AaAaAAaaAAA0AaAaAAAaAAa0AaAaAaAaAaAaAaaaAA0AA0aAA0a0Aa0aAaaaAA0AaaAAAaAAA000A0aaaAAAAaaaAA0aaaAAAAA0AaaAAA0AAaAaAaaaa0AaAaaaAA0aaAA0AAaaAAaaAAA0A0AaAaAaA0aAAaaAaA0aaaAAa0AaAAAAAAaaAAAaAaAaAAA0AaAaA0AaAaAaAAaaAaAaAAA0Aa00AAAaAAAaAaA0AAAaA0AaAAAaAaAaaAA0AA0aAA0aAaaaaAAaaAaAAAAaAaAaA00aAaaaaAAaAaaaaAAaaAaAAAAaAaAaA00aAaaaaaAaAaaaAA0aAa0.\"}"
+          },
+          "cookies": [
+            {
+              "expires": "2021-05-15T05:53:28.000Z",
+              "httpOnly": true,
+              "name": "fpc",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "AvY8b1WTSuBDjxXhMu08S4n-hGN4AQAAANfLCdgOAAAA"
+            },
+            {
+              "httpOnly": true,
+              "name": "x-ms-gateway-slice",
+              "path": "/",
+              "secure": true,
+              "value": "estsfd"
+            },
+            {
+              "httpOnly": true,
+              "name": "stsservicecookie",
+              "path": "/",
+              "secure": true,
+              "value": "estsfd"
+            }
+          ],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-length",
+              "value": "4648"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\""
+            },
+            {
+              "name": "client-request-id",
+              "value": "13e5dcce-917a-4459-b183-64d6b9be24a4"
+            },
+            {
+              "name": "x-ms-request-id",
+              "value": "fff81ca5-0640-4b3e-b8ab-4619a2120800"
+            },
+            {
+              "name": "x-ms-ests-server",
+              "value": "2.1.11622.22 - SEASLR1 ProdSlices"
+            },
+            {
+              "name": "x-ms-clitelem",
+              "value": "1,0,0,,"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "fpc=AvY8b1WTSuBDjxXhMu08S4n-hGN4AQAAANfLCdgOAAAA; expires=Sat, 15-May-2021 05:53:28 GMT; path=/; secure; HttpOnly; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "x-ms-gateway-slice=estsfd; path=/; secure; httponly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "stsservicecookie=estsfd; path=/; secure; httponly"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Apr 2021 05:53:27 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 790,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-04-15T05:53:27.667Z",
+        "time": 515,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 515
+        }
+      },
+      {
+        "_id": "f10e0d424bb6872e6036e5b3e42aee04",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "adobeioruntime.net"
+            },
+            {
+              "name": "user-agent",
+              "value": "helix-fetch"
+            },
+            {
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip,deflate,br"
+            }
+          ],
+          "headersSize": 2665,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "path",
+              "value": "/breaks.docx"
+            },
+            {
+              "name": "shareLink",
+              "value": "https://adobe.sharepoint.com/sites/cg-helix/Shared%20Documents/word2md-unit-tests"
+            },
+            {
+              "name": "rid",
+              "value": ""
+            },
+            {
+              "name": "src",
+              "value": "adobe/theblog/master"
+            }
+          ],
+          "url": "https://adobeioruntime.net/api/v1/web/helix/helix-services/word2md@v2?path=%2Fbreaks.docx&shareLink=https%3A%2F%2Fadobe.sharepoint.com%2Fsites%2Fcg-helix%2FShared%2520Documents%2Fword2md-unit-tests&rid=&src=adobe%2Ftheblog%2Fmaster"
+        },
+        "response": {
+          "bodySize": 149,
+          "content": {
+            "mimeType": "text/plain; charset=UTF-8",
+            "size": 149,
+            "text": "# Breaks\n\n## Bold break\n\n---\n\n## Italic breaks\n\n---\n\n## Break with heading\n\n---\n\n## 3 dashes in paragraph\n\nUse 3 dashes --- to create a new section.\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-store, private, must-revalidate"
+            },
+            {
+              "name": "content-length",
+              "value": "149"
+            },
+            {
+              "name": "content-type",
+              "value": "text/plain; charset=UTF-8"
+            },
+            {
+              "name": "last-modified",
+              "value": "Sat, 27 Mar 2021 07:45:42 GMT"
+            },
+            {
+              "name": "x-request-id",
+              "value": "6vwE1RmtZd9caTIKsVvIB34TPGR9VQ1S"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "Authorization, Origin, X-Requested-With, Content-Type, Accept, User-Agent"
+            },
+            {
+              "name": "x-openwhisk-activation-id",
+              "value": "78ccf152dbf34ff98cf152dbf31ff907"
+            },
+            {
+              "name": "server-timing",
+              "value": "p00;dur=0.04;desc=lookup ,p01;dur=1053.59;desc=resolve ,p02;dur=2004.62;desc=download ,p03;dur=20.87;desc=parseDocx ,p04;dur=0.12;desc=toMdast ,p05;dur=0.30;desc=postProcess ,p06;dur=0.94;desc=toString ,p07;dur=0.00;desc=convert,total;dur=3080.496832"
+            },
+            {
+              "name": "x-last-activation-id",
+              "value": "0c81cba59c37461c81cba59c37e61c75"
+            },
+            {
+              "name": "x-source-location",
+              "value": "/drives/b!DyVXacYnlkm_17hZL307Me9vzRzaKwZCpVMBYbPOKaVT_gD5WmlHRbC-PCpiwGPx/items/012VWERIYIZRNKPJ74HVHKUKOV22RBEFOJ"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "perf-br-resp-out",
+              "value": "1618466011.373"
+            },
+            {
+              "name": "x-gw-cache",
+              "value": "MISS"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=7884000; includeSubDomains"
+            },
+            {
+              "name": "x-envoy-upstream-service-time",
+              "value": "3109"
+            },
+            {
+              "name": "x-azure-ref",
+              "value": "02NR3YAAAAABv6nyDvQW9SIvcEZNoZHn8VFlPMDFFREdFMDUwNwBiNzdiNjYzMy04ZjcwLTQyNWItOTJiZC03NmFlYmU5YWI5YzU="
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Apr 2021 05:53:30 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 1355,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-04-15T05:53:28.226Z",
+        "time": 3190,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3190
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/fixtures/OneDrive-Integration-Tests_690026202/Retrieves-Missing-Document-from-Word_3222296563/recording.har
+++ b/test/fixtures/OneDrive-Integration-Tests_690026202/Retrieves-Missing-Document-from-Word_3222296563/recording.har
@@ -4,11 +4,11 @@
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
-      "version": "4.2.1"
+      "version": "5.1.0"
     },
     "entries": [
       {
-        "_id": "936b0bbd59541f4ff0da124de3123cb2",
+        "_id": "7e2c565ade239d2c05c9e5069a1e5773",
         "_order": 0,
         "cache": {},
         "request": {
@@ -16,27 +16,23 @@
           "cookies": [],
           "headers": [
             {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "accept",
-              "value": "application/json,text/*;q=0.9,*/*;q=0.8"
+              "name": "host",
+              "value": "adobeioruntime.net"
             },
             {
               "name": "user-agent",
               "value": "helix-fetch"
             },
             {
-              "name": "accept-encoding",
-              "value": "br;q=1, gzip;q=0.8, deflate;q=0.5"
+              "name": "accept",
+              "value": "*/*"
             },
             {
-              "name": "host",
-              "value": "adobeioruntime.net"
+              "name": "accept-encoding",
+              "value": "gzip,deflate,br"
             }
           ],
-          "headersSize": 448,
+          "headersSize": 370,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -60,83 +56,90 @@
           "url": "https://adobeioruntime.net/api/v1/web/helix/helix-services/word2md@v2?path=%2Fnot-here.docx&shareLink=https%3A%2F%2Fadobe.sharepoint.com%2Fsites%2FTheBlog%2FShared%2520Documents%2Ftheblog&rid=&src=adobe%2Ftheblog%2Fcb8a0dc5d9d89b800835166783e4130451d3c6a6"
         },
         "response": {
-          "bodySize": 42,
+          "bodySize": 0,
           "content": {
-            "mimeType": "text/html; charset=UTF-8",
-            "size": 42,
-            "text": "no matching documents for \"/not-here.docx\""
+            "mimeType": "text/plain",
+            "size": 0
           },
           "cookies": [],
           "headers": [
             {
-              "name": "access-control-allow-headers",
-              "value": "Authorization, Origin, X-Requested-With, Content-Type, Accept, User-Agent"
+              "name": "cache-control",
+              "value": "no-store, private, must-revalidate"
             },
             {
-              "name": "access-control-allow-methods",
-              "value": "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
+              "name": "x-request-id",
+              "value": "0t95cd3cyWqPy7hbausxx7Kbw90NAkjG"
             },
             {
               "name": "access-control-allow-origin",
               "value": "*"
             },
             {
-              "name": "cache-control",
-              "value": "no-store, private, must-revalidate"
+              "name": "access-control-allow-methods",
+              "value": "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
             },
             {
-              "name": "content-type",
-              "value": "text/html; charset=UTF-8"
+              "name": "access-control-allow-headers",
+              "value": "Authorization, Origin, X-Requested-With, Content-Type, Accept, User-Agent"
             },
             {
-              "name": "date",
-              "value": "Thu, 17 Sep 2020 10:13:37 GMT"
+              "name": "x-openwhisk-activation-id",
+              "value": "e66521e11d0c42b9a521e11d0c12b99c"
             },
             {
-              "name": "strict-transport-security",
-              "value": "max-age=7884000; includeSubDomains"
+              "name": "x-error",
+              "value": "no matching documents for \"/not-here.docx\""
             },
             {
-              "name": "x-content-type-options",
-              "value": "nosniff"
+              "name": "x-last-activation-id",
+              "value": "019d676a0b514d789d676a0b51cd78a6"
             },
             {
               "name": "x-frame-options",
               "value": "deny"
             },
             {
-              "name": "x-last-activation-id",
-              "value": "76e7d4fa12ac40dfa7d4fa12acc0dfc6"
-            },
-            {
-              "name": "x-openwhisk-activation-id",
-              "value": "494c43f0a7aa40468c43f0a7aa7046f8"
-            },
-            {
-              "name": "x-request-id",
-              "value": "vAxLekq0fNZ4YWAYzjlh4S3SGZqvoEZa"
+              "name": "x-content-type-options",
+              "value": "nosniff"
             },
             {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "content-length",
-              "value": "42"
+              "name": "strict-transport-security",
+              "value": "max-age=7884000; includeSubDomains"
+            },
+            {
+              "name": "x-envoy-upstream-service-time",
+              "value": "1047"
+            },
+            {
+              "name": "x-azure-ref",
+              "value": "05tN3YAAAAAAZ1wHvBSEfSqAwWAyJkxFeVFlPMDFFREdFMDUxMgBiNzdiNjYzMy04ZjcwLTQyNWItOTJiZC03NmFlYmU5YWI5YzU="
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Apr 2021 05:49:27 GMT"
             },
             {
               "name": "connection",
-              "value": "keep-alive"
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
             }
           ],
-          "headersSize": 704,
+          "headersSize": 864,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 404,
           "statusText": "Not Found"
         },
-        "startedDateTime": "2020-09-17T10:13:35.880Z",
-        "time": 1731,
+        "startedDateTime": "2021-04-15T05:49:26.343Z",
+        "time": 1141,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -144,7 +147,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1731
+          "wait": 1141
         }
       }
     ],

--- a/test/google-reverse.test.js
+++ b/test/google-reverse.test.js
@@ -109,7 +109,7 @@ describe('Google Reverse Lookup Tests', () => {
     }, DEFAULT_ENV);
 
     assert.equal(result.statusCode, 302);
-    assert.equal(result.headers.location, 'https://theblog--adobe.hlx.page/gdocs/helix-hackathon-part-v');
+    assert.equal(result.headers.location, 'https://master--theblog--adobe.hlx.page/gdocs/helix-hackathon-part-v');
   }).timeout(50000);
 
   it('Returns redirect for google document (base64)', async function googleSheet() {
@@ -126,7 +126,7 @@ describe('Google Reverse Lookup Tests', () => {
     }, DEFAULT_ENV);
 
     assert.equal(result.statusCode, 302);
-    assert.equal(result.headers.location, 'https://theblog--adobe.hlx.page/gdocs/helix-hackathon-part-v');
+    assert.equal(result.headers.location, 'https://master--theblog--adobe.hlx.page/gdocs/helix-hackathon-part-v');
   }).timeout(50000);
 
   it('Returns redirect for google document (main branch)', async function googleSheet() {
@@ -144,7 +144,7 @@ describe('Google Reverse Lookup Tests', () => {
     }, DEFAULT_ENV);
 
     assert.equal(result.statusCode, 302);
-    assert.equal(result.headers.location, 'https://theblog--adobe.hlx.page/gdocs/helix-hackathon-part-v');
+    assert.equal(result.headers.location, 'https://main--theblog--adobe.hlx.page/gdocs/helix-hackathon-part-v');
   }).timeout(50000);
 
   it('Returns redirect for google document (non default branch)', async function googleSheet() {
@@ -231,7 +231,7 @@ describe('Google Reverse Lookup Tests', () => {
     }, DEFAULT_ENV);
 
     assert.equal(result.statusCode, 302);
-    assert.equal(result.headers.location, 'https://theblog--adobe.hlx.page/gdocs/country-codes.json');
+    assert.equal(result.headers.location, 'https://master--theblog--adobe.hlx.page/gdocs/country-codes.json');
   }).timeout(50000);
 
   it('Returns redirect for google document (gdrive uri)', async function googleSheet() {
@@ -248,7 +248,7 @@ describe('Google Reverse Lookup Tests', () => {
     }, DEFAULT_ENV);
 
     assert.equal(result.statusCode, 302);
-    assert.equal(result.headers.location, 'https://theblog--adobe.hlx.page/gdocs/helix-hackathon-part-v');
+    assert.equal(result.headers.location, 'https://master--theblog--adobe.hlx.page/gdocs/helix-hackathon-part-v');
   }).timeout(50000);
 
   it('Returns 404 for not existent google document', async function googleSheet() {

--- a/test/onedrive-json.test.js
+++ b/test/onedrive-json.test.js
@@ -108,6 +108,16 @@ class FakeOneDrive {
   }
 }
 
+const FakeOnedriveHelper = {
+  getOneDriveClient() {
+    return new FakeOneDrive();
+  },
+
+  getAccessToken() {
+    return '';
+  },
+};
+
 describe('Excel JSON Integration tests', () => {
   setupPolly({
     recordIfMissing: false,
@@ -136,9 +146,7 @@ describe('Excel JSON Integration tests', () => {
 
   it('Get JSON', async () => {
     const { handleJSON: original } = proxyquire('../src/onedrive-json', {
-      '@adobe/helix-onedrive-support': {
-        OneDrive: FakeOneDrive,
-      },
+      './onedrive-helpers.js': FakeOnedriveHelper,
     });
     const handleJSON = retrofit(original);
 
@@ -199,11 +207,8 @@ describe('Excel JSON Integration tests', () => {
   }).timeout(50000);
 
   it('Get JSON on author friendly url', async () => {
-    // const { handleJSON } = require('../src/onedrive-json');
     const { handleJSON: original } = proxyquire('../src/onedrive-json', {
-      '@adobe/helix-onedrive-support': {
-        OneDrive: FakeOneDrive,
-      },
+      './onedrive-helpers.js': FakeOnedriveHelper,
     });
     const handleJSON = retrofit(original);
 
@@ -262,9 +267,7 @@ describe('Excel JSON Integration tests', () => {
 
   it('Get missing JSON', async () => {
     const { handleJSON: original } = proxyquire('../src/onedrive-json', {
-      '@adobe/helix-onedrive-support': {
-        OneDrive: FakeOneDrive,
-      },
+      './onedrive-helpers.js': FakeOnedriveHelper,
     });
     const handleJSON = retrofit(original);
 
@@ -294,9 +297,7 @@ describe('Excel JSON Integration tests', () => {
 
   it('Get missing JSON from data-embed', async function test() {
     const { handleJSON: original } = proxyquire('../src/onedrive-json', {
-      '@adobe/helix-onedrive-support': {
-        OneDrive: FakeOneDrive,
-      },
+      './onedrive-helpers.js': FakeOnedriveHelper,
     });
     const handleJSON = retrofit(original);
 
@@ -330,9 +331,7 @@ describe('Excel JSON Integration tests', () => {
 
   it('Get bad JSON', async function test() {
     const { handleJSON: original } = proxyquire('../src/onedrive-json', {
-      '@adobe/helix-onedrive-support': {
-        OneDrive: FakeOneDrive,
-      },
+      './onedrive-helpers.js': FakeOnedriveHelper,
     });
     const handleJSON = retrofit(original);
 
@@ -365,9 +364,7 @@ describe('Excel JSON Integration tests', () => {
 
   it('Get timeout', async function test() {
     const { handleJSON: original } = proxyquire('../src/onedrive-json', {
-      '@adobe/helix-onedrive-support': {
-        OneDrive: FakeOneDrive,
-      },
+      './onedrive-helpers.js': FakeOnedriveHelper,
     });
     const handleJSON = retrofit(original);
 


### PR DESCRIPTION
fixes #376

adds multi user support by reading the fstab and decrypting the credentials.
the credentials can either be username/password pairs:

```
{"u":"username", "p":"password"}
```

or a refresh token:
```
{"r":"....."}
```

use the `test/dev/creds.js` to encrypt the credentials with a github token, and then add them to a fstab entry. eg:

```
      mountpoints:
        /: 
          url: https://my.sharepoint.com/foo
          credentials: "abcdef=="
```

**Limitations**

- only onedrive/sharepoint support yet
- for the reverse lookup (sharepoint -> website), only the first fstab entry with valid credentials are respected, due to a chicken-and-egg problem :-)

**Notes**

- if present, the credentials are used to authenticate against MS and the access token is passed along via the `authorization` header to word2md and data-embed.
- if (for whatever reason) no access token can be retrieved, the donwstream services will do their usual authentication (using the package-defined default user).